### PR TITLE
Persist Redux store and use it for survey definitions

### DIFF
--- a/app/config/store.js
+++ b/app/config/store.js
@@ -12,7 +12,8 @@ const middleware = () => {
 const store = compose(autoRehydrate())(createStore)(reducers, middleware());
 
 persistStore(store, {
-  storage: AsyncStorage
+  storage: AsyncStorage,
+  whitelist: ["surveys"]
 });
 
 export default store;

--- a/app/config/store.js
+++ b/app/config/store.js
@@ -1,5 +1,7 @@
-import { applyMiddleware, createStore } from "redux";
+import { AsyncStorage } from "react-native";
+import { applyMiddleware, compose, createStore } from "redux";
 import { createLogger } from "redux-logger";
+import { persistStore, autoRehydrate } from "redux-persist";
 
 import reducers from "../reducers";
 
@@ -7,4 +9,10 @@ const middleware = () => {
   return applyMiddleware(createLogger());
 };
 
-export default createStore(reducers, middleware());
+const store = compose(autoRehydrate())(createStore)(reducers, middleware());
+
+persistStore(store, {
+  storage: AsyncStorage
+});
+
+export default store;

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -6,10 +6,12 @@ import {
   reducer as createObservation
 } from "../screens/CreateObservation/navigator";
 import { reducer as observations } from "../screens/Observations/navigator";
+import surveys from "./surveys";
 
 export default combineReducers({
   account,
   app,
   createObservation,
-  observations
+  observations,
+  surveys
 });

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -1,0 +1,7 @@
+import survey from "../config/survey";
+
+const initialState = [survey];
+
+export default (state = initialState, action) => {
+  return state;
+};

--- a/app/screens/CreateObservation/add-observation.js
+++ b/app/screens/CreateObservation/add-observation.js
@@ -1,11 +1,11 @@
 import React, { Component } from "react";
 import { StyleSheet, View, TouchableHighlight } from "react-native";
 import { NavigationActions } from "react-navigation";
+import { connect } from "react-redux";
 
 import { Text, Wrapper } from "../../components";
 import { getFieldType } from "../../components/fields";
 import { baseStyles } from "../../styles";
-import survey from "../../config/survey.json";
 
 const styles = StyleSheet.create({
   sectionTitle: {
@@ -21,21 +21,6 @@ const styles = StyleSheet.create({
 });
 
 class AddObservationScreen extends Component {
-  componentWillMount() {
-    console.log("props:", this.props);
-    const {
-      navigation: { state: { params: { observationType } } }
-    } = this.props;
-
-    const type = survey.featureTypes.find(x => x.id === observationType);
-
-    console.log("type:", type);
-
-    this.setState({
-      type
-    });
-  }
-
   onBackPress = () => this.props.navigation.dispatch(NavigationActions.back());
 
   renderField(field, index) {
@@ -57,7 +42,7 @@ class AddObservationScreen extends Component {
   }
 
   render() {
-    const { type: { fields, name } } = this.state;
+    const { type: { fields, name } } = this.props;
 
     return (
       <Wrapper>
@@ -125,4 +110,16 @@ class AddObservationScreen extends Component {
   }
 }
 
-export default AddObservationScreen;
+const mapStateToProps = (state, ownProps) => {
+  const survey = state.surveys[0];
+
+  const { navigation: { state: { params: { observationType } } } } = ownProps;
+
+  const type = survey.featureTypes.find(x => x.id === observationType);
+
+  return {
+    type
+  };
+};
+
+export default connect(mapStateToProps)(AddObservationScreen);

--- a/app/screens/CreateObservation/categories.js
+++ b/app/screens/CreateObservation/categories.js
@@ -1,13 +1,9 @@
 import React, { Component } from "react";
 import { StyleSheet, View, ListView, TouchableHighlight } from "react-native";
+import { connect } from "react-redux";
 
 import { Text, Wrapper } from "../../components";
 import { baseStyles } from "../../styles";
-import survey from "../../config/survey.json";
-
-const observationTypes = survey.observationTypes.map(t =>
-  survey.featureTypes.find(x => x.id === t)
-);
 
 const styles = StyleSheet.create({
   gridContainer: {
@@ -34,6 +30,8 @@ const styles = StyleSheet.create({
 
 class CategoriesScreen extends Component {
   componentWillMount() {
+    const { observationTypes } = this.props;
+
     const ds = new ListView.DataSource({
       rowHasChanged: (r1, r2) => r1 !== r2
     });
@@ -84,4 +82,16 @@ class CategoriesScreen extends Component {
   }
 }
 
-export default CategoriesScreen;
+const mapStateToProps = state => {
+  const survey = state.surveys[0];
+
+  const observationTypes = survey.observationTypes.map(t =>
+    survey.featureTypes.find(x => x.id === t)
+  );
+
+  return {
+    observationTypes
+  };
+};
+
+export default connect(mapStateToProps)(CategoriesScreen);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "react-navigation": "^1.0.0-beta.9",
     "react-redux": "^5.0.5",
     "redux": "^3.6.0",
-    "redux-logger": "^3.0.6"
+    "redux-logger": "^3.0.6",
+    "redux-persist": "^4.8.0"
   },
   "devDependencies": {
     "babel-preset-react-native": "1.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,7 +2850,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -3216,7 +3216,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.2.0, lodash-es@^4.2.1:
+lodash-es@^4.17.4, lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
 
@@ -3335,7 +3335,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4456,6 +4456,14 @@ redux-logger@^3.0.6:
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
   dependencies:
     deep-diff "^0.3.5"
+
+redux-persist@^4.8.0:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-4.8.0.tgz#17fd998949bdeef9275e4cf60ad5bbe1c73675fc"
+  dependencies:
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.4"
+    lodash-es "^4.17.4"
 
 redux@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
This will (eventually) persist the Redux store to AsyncStorage, allowing us to rely on the presence of things outside of osm-p2p (including navigation state, though it's problematic and potentially undesired; it would only kick in when reloading JS or upgrading the app).

Not ready for primetime yet, as restoring view stacks throws exceptions,  possibly related to Mapbox GL (`removeViewAt` in `ReactNativeMapboxGLManager:149` is in the stack):

```
Attempt to invoke virtual method 'void android.view.View.unFocus(android.view.View)' on a null object reference
```