### PR TITLE
Add react-native-udp to project.

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -134,6 +134,7 @@ android {
 
 dependencies {
     compile project(':react-native-interactable')
+    compile project(':react-native-udp')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/android/app/src/main/java/com/surveyor/MainApplication.java
+++ b/android/app/src/main/java/com/surveyor/MainApplication.java
@@ -3,6 +3,7 @@ package com.surveyor;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.tradle.react.UdpSocketsModule;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
@@ -28,6 +29,7 @@ public class MainApplication extends Application implements ReactApplication {
       return Arrays.<ReactPackage>asList(
         new MainReactPackage(),
         new Interactable(),
+        new UdpSocketsModule(),
         new ReactNativeMapboxGLPackage(),
         new ReactNativeLocalizationPackage()
       );

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'Surveyor'
+include ':react-native-udp'
+project(':react-native-udp').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-udp/android')
 
 include ':app'
 

--- a/ios/Surveyor.xcodeproj/project.pbxproj
+++ b/ios/Surveyor.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		47050CAE6DEA475BAA3939DF /* libInteractable.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5C42201003FE43B39CFE2467 /* libInteractable.a */; };
 		3CAE24E199234F0AB2352AA9 /* libReactNativeLocalization.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C1C0DDEE2C7456BB1BE0E8B /* libReactNativeLocalization.a */; };
 		9144ED39E1E849EC8102A174 /* libRCTMapboxGL.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5FFEFFB7F62A4D45BFDD8B51 /* libRCTMapboxGL.a */; };
+		FE3D2430279B48BDAB722AA0 /* libUdpSockets.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C0942C44DC7246BD98AB2EC2 /* libUdpSockets.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -263,6 +264,8 @@
 		9C1C0DDEE2C7456BB1BE0E8B /* libReactNativeLocalization.a */ = {isa = PBXFileReference; name = "libReactNativeLocalization.a"; path = "libReactNativeLocalization.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 		E799F954175B49B8B46A8ABE /* RCTMapboxGL.xcodeproj */ = {isa = PBXFileReference; name = "RCTMapboxGL.xcodeproj"; path = "../node_modules/react-native-mapbox-gl/ios/RCTMapboxGL.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
 		5FFEFFB7F62A4D45BFDD8B51 /* libRCTMapboxGL.a */ = {isa = PBXFileReference; name = "libRCTMapboxGL.a"; path = "libRCTMapboxGL.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		3BDD59C2ED264EA882DB3431 /* UdpSockets.xcodeproj */ = {isa = PBXFileReference; name = "UdpSockets.xcodeproj"; path = "../node_modules/react-native-udp/ios/UdpSockets.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		C0942C44DC7246BD98AB2EC2 /* libUdpSockets.a */ = {isa = PBXFileReference; name = "libUdpSockets.a"; path = "libUdpSockets.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +295,7 @@
 				47050CAE6DEA475BAA3939DF /* libInteractable.a in Frameworks */,
 				3CAE24E199234F0AB2352AA9 /* libReactNativeLocalization.a in Frameworks */,
 				9144ED39E1E849EC8102A174 /* libRCTMapboxGL.a in Frameworks */,
+				FE3D2430279B48BDAB722AA0 /* libUdpSockets.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -461,6 +465,7 @@
 				AC3F5766E6FA4CB3B90FE812 /* Interactable.xcodeproj */,
 				68978AB0B8A042E4898B145A /* ReactNativeLocalization.xcodeproj */,
 				E799F954175B49B8B46A8ABE /* RCTMapboxGL.xcodeproj */,
+				3BDD59C2ED264EA882DB3431 /* UdpSockets.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -997,6 +1002,7 @@
 					"$(SRCROOT)/../node_modules/react-native-interactable/ios/Interactable",
 					"$(SRCROOT)/../node_modules/react-native-localization",
 					"$(SRCROOT)/../node_modules/react-native-mapbox-gl/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 				);
 			};
 			name = Debug;
@@ -1026,6 +1032,7 @@
 					"$(SRCROOT)/../node_modules/react-native-interactable/ios/Interactable",
 					"$(SRCROOT)/../node_modules/react-native-localization",
 					"$(SRCROOT)/../node_modules/react-native-mapbox-gl/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 				);
 			};
 			name = Release;
@@ -1050,6 +1057,7 @@
 					"$(SRCROOT)/../node_modules/react-native-interactable/ios/Interactable",
 					"$(SRCROOT)/../node_modules/react-native-localization",
 					"$(SRCROOT)/../node_modules/react-native-mapbox-gl/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 				);
 			};
 			name = Debug;
@@ -1073,6 +1081,7 @@
 					"$(SRCROOT)/../node_modules/react-native-interactable/ios/Interactable",
 					"$(SRCROOT)/../node_modules/react-native-localization",
 					"$(SRCROOT)/../node_modules/react-native-mapbox-gl/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 				);
 			};
 			name = Release;
@@ -1111,6 +1120,7 @@
 					"$(SRCROOT)/../node_modules/react-native-interactable/ios/Interactable",
 					"$(SRCROOT)/../node_modules/react-native-localization",
 					"$(SRCROOT)/../node_modules/react-native-mapbox-gl/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 				);
 			};
 			name = Debug;
@@ -1149,6 +1159,7 @@
 					"$(SRCROOT)/../node_modules/react-native-interactable/ios/Interactable",
 					"$(SRCROOT)/../node_modules/react-native-localization",
 					"$(SRCROOT)/../node_modules/react-native-mapbox-gl/ios/**",
+					"$(SRCROOT)/../node_modules/react-native-udp/ios/**",
 				);
 			};
 			name = Release;
@@ -1174,8 +1185,6 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 			};
 			name = Debug;
@@ -1200,8 +1209,6 @@
 				TVOS_DEPLOYMENT_TARGET = 10.1;
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
-					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 			};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "asyncstorage-down": "sethvincent/asyncstorage-down",
     "babel-plugin-rewrite-require": "^1.9.1",
+    "bonjour": "github:noffle/bonjour",
     "buffer": "^5.0.6",
     "d64": "^1.0.0",
     "hyperlog": "github:sethvincent/hyperlog",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "asyncstorage-down": "sethvincent/asyncstorage-down",
     "babel-plugin-rewrite-require": "^1.9.1",
+    "buffer": "^5.0.6",
     "d64": "^1.0.0",
     "hyperlog": "github:sethvincent/hyperlog",
     "levelup": "^1.3.6",
@@ -25,6 +26,7 @@
     "react-native-level-fs": "^3.0.0",
     "react-native-localization": "^0.1.30",
     "react-native-mapbox-gl": "sethvincent/react-native-mapbox-gl#field-data",
+    "react-native-udp": "^2.0.0",
     "react-navigation": "^1.0.0-beta.11",
     "react-redux": "^5.0.5",
     "redux": "^3.6.0",


### PR DESCRIPTION
This adds `react-native-udp` as well as a specialized fork of @watson's
`bonjour` that points to a fork of @mafintosh's `multicast-dns` in order to
depend on `react-native-udp` instead of `dgram`.