### PR TITLE
add react-native-pie-chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-native-level-fs": "^3.0.0",
     "react-native-localization": "^0.1.30",
     "react-native-mapbox-gl": "sethvincent/react-native-mapbox-gl#field-data",
+    "react-native-pie-chart": "sethvincent/react-native-pie-chart",
     "react-native-udp": "^2.0.0",
     "react-native-vector-icons": "^4.2.0",
     "react-navigation": "^1.0.0-beta.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5444,6 +5444,10 @@ react-native-mapbox-gl@sethvincent/react-native-mapbox-gl#field-data:
     lodash "^4.13.1"
     prop-types "^15.5.10"
 
+react-native-pie-chart@sethvincent/react-native-pie-chart:
+  version "1.0.11"
+  resolved "https://codeload.github.com/sethvincent/react-native-pie-chart/tar.gz/456b83a8e2e4cb96b415acdb79ad7a3cfab028e2"
+
 react-native-tab-view@^0.0.65:
   version "0.0.65"
   resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.65.tgz#b685ea3081ff7c96486cd997361026c407302c59"


### PR DESCRIPTION
example usage:

```js
import PieChart from 'react-native-pie-chart';

<PieChart
  chart_wh={100}
  series={[20, 80]}
  sliceColor={['#F44336','#2196F3']}
  doughnut={true}
  coverRadius={0.45}
  coverFill={'#FFF'}
/>
```

note: i forked this to update `PropTypes` stuff and the pr is here: https://github.com/genexu/react-native-pie-chart/pull/11