### PR TITLE
syncing osm data & observations on survey import

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -118,7 +118,7 @@ const syncSurveyData = (id, target, dispatch) => {
     });
   };
 
-  osm.replicate(target, { progressFn }, function(err) {
+  osm.replicate(target, { progressFn }, err => {
     if (err) {
       return dispatch({
         type: types.SYNCING_SURVEY_DATA_FAILED,

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -105,8 +105,6 @@ const extractSurveyBundle = (id, bundle, _callback) => {
 };
 
 const syncSurveyData = (id, target, dispatch) => {
-  console.log("does this happen", target);
-
   dispatch({
     type: types.SYNCING_SURVEY_DATA,
     id
@@ -122,14 +120,12 @@ const syncSurveyData = (id, target, dispatch) => {
 
   osm.replicate(target, { progressFn }, function(err) {
     if (err) {
-      console.log(types.SYNCING_SURVEY_DATA_FAILED);
       return dispatch({
         type: types.SYNCING_SURVEY_DATA_FAILED,
         id
       });
     }
 
-    console.log(types.FINISHED_SYNCING_SURVEY_DATA);
     dispatch({
       type: types.FINISHED_SYNCING_SURVEY_DATA,
       id

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -41,6 +41,7 @@ const types = {
   RECEIVED_REMOTE_SURVEY_LIST: "RECEIVED_REMOTE_SURVEY_LIST",
   RECEIVED_REMOTE_SURVEY: "RECEIVED_REMOTE_SURVEY",
   SYNCING_SURVEY_DATA: "SYNCING_SURVEY_DATA",
+  SYNCING_SURVEY_DATA_PROGRESS: "SYNCING_SURVEY_DATA_PROGRESS",
   SYNCING_SURVEY_DATA_FAILED: "SYNCING_SURVEY_DATA_FAILED",
   FINISHED_SYNCING_SURVEY_DATA: "FINISHED_SYNCING_SURVEY_DATA"
 };
@@ -103,28 +104,35 @@ const extractSurveyBundle = (id, bundle, _callback) => {
   bundle.open();
 };
 
-const syncSurveyData = (target, dispatch) => {
+const syncSurveyData = (id, target, dispatch) => {
   console.log("does this happen", target);
 
   dispatch({
-    type: types.SYNCING_SURVEY_DATA
+    type: types.SYNCING_SURVEY_DATA,
+    id
   });
 
   const progressFn = i => {
-    console.log("progress", i);
+    dispatch({
+      type: types.SYNCING_SURVEY_DATA_PROGRESS,
+      progress: i,
+      id
+    });
   };
 
   osm.replicate(target, { progressFn }, function(err) {
     if (err) {
       console.log(types.SYNCING_SURVEY_DATA_FAILED);
       return dispatch({
-        type: types.SYNCING_SURVEY_DATA_FAILED
+        type: types.SYNCING_SURVEY_DATA_FAILED,
+        id
       });
     }
 
     console.log(types.FINISHED_SYNCING_SURVEY_DATA);
     dispatch({
-      type: types.FINISHED_SYNCING_SURVEY_DATA
+      type: types.FINISHED_SYNCING_SURVEY_DATA,
+      id
     });
   });
 };
@@ -188,7 +196,7 @@ export const fetchRemoteSurvey = (id, url, target) => (dispatch, getState) => {
         survey
       });
 
-      syncSurveyData(target, dispatch);
+      syncSurveyData(id, target, dispatch);
     })
     .catch(error =>
       dispatch({

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -206,7 +206,7 @@ export const clearRemoteSurveys = () => (dispatch, getState) =>
     type: types.CLEAR_REMOTE_SURVEYS
   });
 
-export const fetchRemoteSurvey = (id, url, target) => (dispatch, getState) => {
+export const fetchRemoteSurvey = (id, url) => (dispatch, getState) => {
   dispatch({
     id,
     type: types.FETCHING_REMOTE_SURVEY

--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -229,8 +229,10 @@ export const listRemoteSurveys = () => (dispatch, getState) => {
           surveys: surveys.map(x => ({
             ...x,
             url: `http://${targetIP}:${targetPort}/surveys/${x.id}`,
-            ip: targetIP,
-            port: targetPort
+            target: {
+              address: targetIP,
+              port: targetPort
+            }
           }))
         })
       )

--- a/app/components/side-menu.js
+++ b/app/components/side-menu.js
@@ -41,10 +41,6 @@ const styles = StyleSheet.create({
 });
 
 class SideMenu extends Component {
-  componentWillMount() {
-    this._osm = this.props.osm;
-  }
-
   open = () => {
     this._menu.setVelocity({ x: -2000 });
   };
@@ -71,29 +67,6 @@ class SideMenu extends Component {
 
           <View style={styles.sideMenu}>
             <Text style={[baseStyles.title, baseStyles.titleMenu]}>Menu</Text>
-
-            <TouchableOpacity
-              style={{ paddingLeft: 30 }}
-              onPress={() => {
-                var ws = websocket("ws://10.0.2.2:3000");
-
-                this._osm.sync(ws, err => {
-                  if (err) console.log(err);
-                  this._osm.ready(onSync);
-                });
-              }}
-            >
-              <Text>Sync Data</Text>
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={{ paddingLeft: 30 }}
-              onPress={() => {
-                AsyncStorage.clear(function(err) {});
-              }}
-            >
-              <Text>Delete data</Text>
-            </TouchableOpacity>
 
             <TouchableOpacity
               style={[baseStyles.navLink]}

--- a/app/config/store.js
+++ b/app/config/store.js
@@ -19,7 +19,7 @@ const store = compose(autoRehydrate())(createStore)(reducers, middleware());
 
 persistStore(store, {
   storage: FilesystemStorage,
-  whitelist: ["surveys"]
+  whitelist: ["surveys", "osm"]
 });
 
 export default store;

--- a/app/lib/osm-p2p.js
+++ b/app/lib/osm-p2p.js
@@ -108,11 +108,7 @@ function osmp2p(observationDb, osmOrgDb) {
     return pump(osmStream, geoJSONStream);
   }
 
-  function replicate(opts) {
-    return observationDb.log.replicate(opts);
-  }
-
-  function replicateNet(addr, opts, cb) {
+  function replicate(addr, opts, cb) {
     netSync.replicate(addr, opts, cb);
   }
 

--- a/app/lib/osm-sync.js
+++ b/app/lib/osm-sync.js
@@ -29,12 +29,14 @@ OsmSync.prototype.replicate = function(target, opts, done) {
   opts.progressFn(0);
 
   function onFinish(err) {
-    console.log("finished replicating", finished);
     if (err) {
       finished--;
       return done(err);
     }
-    if (++finished === 2) done();
+    if (++finished === 2) {
+      console.log("finished replicating", finished);
+      done();
+    }
     opts.progressFn(finished / 2);
   }
 };

--- a/app/lib/osm-sync.js
+++ b/app/lib/osm-sync.js
@@ -33,11 +33,13 @@ OsmSync.prototype.replicate = function(target, opts, done) {
       finished--;
       return done(err);
     }
-    if (++finished === 2) {
+
+    opts.progressFn(++finished / 2);
+
+    if (finished === 2) {
       console.log("finished replicating", finished);
-      done();
+      return done();
     }
-    opts.progressFn(finished / 2);
   }
 };
 

--- a/app/reducers/index.js
+++ b/app/reducers/index.js
@@ -6,10 +6,12 @@ import { reducer as createObservation } from "../screens/CreateObservation/navig
 
 import status from "./status";
 import surveys from "./surveys";
+import osm from "./osm";
 
 export default combineReducers({
   app,
   createObservation,
   status,
-  surveys
+  surveys,
+  osm
 });

--- a/app/reducers/osm.js
+++ b/app/reducers/osm.js
@@ -1,0 +1,18 @@
+import types from "../actions";
+
+const initialState = {
+  areaOfInterest: null
+};
+
+export default (state = initialState, { areaOfInterest, type }) => {
+  switch (type) {
+    case types.SET_AREA_OF_INTEREST:
+      return {
+        ...state,
+        areaOfInterest
+      };
+
+    default:
+      return state;
+  }
+};

--- a/app/reducers/status.js
+++ b/app/reducers/status.js
@@ -58,6 +58,27 @@ export default (state = initialState, { error, type }) => {
         message: null
       };
 
+    case types.SYNCING_SURVEY_DATA:
+      return {
+        ...state,
+        error,
+        message: "Syncing survey data..."
+      };
+
+    case types.SYNCING_SURVEY_DATA_FAILED:
+      return {
+        ...state,
+        error,
+        message: "Syncing survey data failed."
+      };
+
+    case types.FINISHED_SYNCING_SURVEY_DATA:
+      return {
+        ...state,
+        error,
+        message: "Survey data sync complete."
+      };
+
     default:
       return state;
   }

--- a/app/screens/Account/RemoteSurveyList.js
+++ b/app/screens/Account/RemoteSurveyList.js
@@ -17,11 +17,7 @@ export default class RemoteSurveyList extends Component {
         {surveys.map((survey, idx) =>
           <TouchableOpacity
             key={idx}
-            onPress={() =>
-              fetch(survey.id, survey.url, {
-                address: survey.ip,
-                port: survey.port
-              })}
+            onPress={() => fetch(survey.id, survey.url, survey.target)}
             style={[baseStyles.touchableLinksWrapper]}
           >
             <Text style={[baseStyles.touchableLinks]}>

--- a/app/screens/Account/RemoteSurveyList.js
+++ b/app/screens/Account/RemoteSurveyList.js
@@ -17,7 +17,11 @@ export default class RemoteSurveyList extends Component {
         {surveys.map((survey, idx) =>
           <TouchableOpacity
             key={idx}
-            onPress={() => fetch(survey.id, survey.url)}
+            onPress={() =>
+              fetch(survey.id, survey.url, {
+                address: survey.ip,
+                port: survey.port
+              })}
             style={[baseStyles.touchableLinksWrapper]}
           >
             <Text style={[baseStyles.touchableLinks]}>

--- a/app/screens/Account/RemoteSurveyList.js
+++ b/app/screens/Account/RemoteSurveyList.js
@@ -3,10 +3,11 @@ import { TouchableOpacity, View } from "react-native";
 
 import { Text } from "../../components";
 import { baseStyles } from "../../styles";
+import { syncSurveyData } from "../../actions";
 
 export default class RemoteSurveyList extends Component {
   render() {
-    const { fetch, surveys } = this.props;
+    const { fetch, surveys, sync } = this.props;
 
     if (surveys == null || surveys.length === 0) {
       return null;
@@ -17,7 +18,10 @@ export default class RemoteSurveyList extends Component {
         {surveys.map((survey, idx) =>
           <TouchableOpacity
             key={idx}
-            onPress={() => fetch(survey.id, survey.url, survey.target)}
+            onPress={() => {
+              fetch(survey.id, survey.url);
+              sync(survey);
+            }}
             style={[baseStyles.touchableLinksWrapper]}
           >
             <Text style={[baseStyles.touchableLinks]}>

--- a/app/screens/Account/SurveyModal.js
+++ b/app/screens/Account/SurveyModal.js
@@ -6,7 +6,8 @@ import { connect } from "react-redux";
 import {
   clearRemoteSurveys,
   fetchRemoteSurvey,
-  listRemoteSurveys
+  listRemoteSurveys,
+  syncSurveyData
 } from "../../actions";
 import { StatusBar, Text } from "../../components";
 import RemoteSurveyList from "./RemoteSurveyList";
@@ -20,7 +21,12 @@ class SurveyModal extends Component {
   }
 
   render() {
-    const { close, fetchRemoteSurvey, remoteSurveys } = this.props;
+    const {
+      close,
+      fetchRemoteSurvey,
+      remoteSurveys,
+      syncSurveyData
+    } = this.props;
 
     return (
       <Modal animationType="slide" transparent visible onRequestClose={close}>
@@ -35,7 +41,11 @@ class SurveyModal extends Component {
               <Icon name="clear" style={[[baseStyles.clearIcon]]} />
             </TouchableOpacity>
           </View>
-          <RemoteSurveyList fetch={fetchRemoteSurvey} surveys={remoteSurveys} />
+          <RemoteSurveyList
+            fetch={fetchRemoteSurvey}
+            sync={syncSurveyData}
+            surveys={remoteSurveys}
+          />
           <TouchableOpacity onPress={close} style={[baseStyles.buttonBottom]}>
             <Text style={[baseStyles.textWhite]}>
               {"Done".toUpperCase()}
@@ -54,5 +64,6 @@ const mapStateToProps = state => ({
 export default connect(mapStateToProps, {
   clearRemoteSurveys,
   fetchRemoteSurvey,
-  listRemoteSurveys
+  listRemoteSurveys,
+  syncSurveyData
 })(SurveyModal);

--- a/app/screens/Account/surveys.js
+++ b/app/screens/Account/surveys.js
@@ -29,9 +29,9 @@ class SurveysScreen extends Component {
     });
 
   // uncomment this to clear local surveys when displaying this screen
-  // componentWillMount() {
-  //   this.props.clearLocalSurveys();
-  // }
+  componentWillMount() {
+    this.props.clearLocalSurveys();
+  }
 
   render() {
     const { availableSurveys, navigation } = this.props;

--- a/app/screens/Account/surveys.js
+++ b/app/screens/Account/surveys.js
@@ -29,9 +29,9 @@ class SurveysScreen extends Component {
     });
 
   // uncomment this to clear local surveys when displaying this screen
-  componentWillMount() {
-    this.props.clearLocalSurveys();
-  }
+  // componentWillMount() {
+  //   this.props.clearLocalSurveys();
+  // }
 
   render() {
     const { availableSurveys, navigation } = this.props;

--- a/app/screens/Observations/map.js
+++ b/app/screens/Observations/map.js
@@ -55,9 +55,6 @@ class ObservationMapScreen extends Component {
     super();
 
     this.navigationOptions = { tabBarLabel: "Map" };
-    this._obsdb = createOsmp2p("obs");
-    this._osmdb = createOsmp2p("osm");
-    this._osm = osmp2p(this._obsdb, this._osmdb);
   }
 
   componentWillMount() {
@@ -94,11 +91,7 @@ class ObservationMapScreen extends Component {
 
     this._map.getBoundsFromScreenCoordinates(rect, bounds => {
       console.log("bounds from screenCoords", bounds);
-      var q = [[bounds[0], bounds[2]], [bounds[1], bounds[3]]];
-
-      this._osm.listAnnotations(q, (err, annotations) => {
-        console.log("annotations.length", annotations.length);
-      });
+      // TODO: trigger action fetching points within bounds
     });
   };
 
@@ -106,11 +99,7 @@ class ObservationMapScreen extends Component {
     this._map.getBounds(data => {
       var q = [[data[0], data[2]], [data[1], data[3]]];
 
-      this._osm.listAnnotations(q, (err, annotations) => {
-        if (annotations) {
-          this.setState({ annotations });
-        }
-      });
+      // TODO: trigger action fetching points within bounds
     });
   };
 
@@ -128,7 +117,6 @@ class ObservationMapScreen extends Component {
             this._menu = menu;
           }}
           navigation={this.props.navigation}
-          osm={this._osm}
           onSync={this.prepareAnnotations}
         />
 


### PR DESCRIPTION
Some notes on how to make the desktop & mobile apps talk to each other, which could be improved & turned into a docs file later:

## Steps to import a survey & sync data:

### desktop app
- open the desktop app (https://github.com/osmlab/field-data-coordinator)
- choose "surveys" form the menu to go to the surveys page
- click "import" to import a survey
  - for example: https://github.com/osmlab/field-data-collection/blob/master/data/surveys/sri_lanka/survey.yaml
- select a geographic area

### mobile app
- open the mobile app
- open the menu and choose "Surveys"
- touch "ADD NEW SURVEYS"
- select the survey you want to add
- wait for import to finish