### PR TITLE
Add helper functions for fetching observations

### DIFF
--- a/app/lib/observations.js
+++ b/app/lib/observations.js
@@ -1,0 +1,99 @@
+const amap = require("async").map;
+const through = require("through2");
+const concat = require("concat-stream");
+
+module.exports = {
+  getObservationsByNode,
+  getObservationsBySurveyId,
+  getObservationsByDeviceId
+};
+
+function getObservationsByNode(nodeId, observationsDb, observationsIndex, cb) {
+  observationsIndex.links(nodeId, function(err, docs) {
+    if (err) return cb(err);
+
+    amap(docs, observationLinkToObservation, function(err, res) {
+      if (err) return cb(err);
+      res = res.filter(item => !!item);
+      cb(null, res);
+    });
+
+    function observationLinkToObservation(link, done) {
+      var obsId = link.value.obs;
+      observationsDb.get(obsId, function(err, heads) {
+        if (err) return done(err);
+        var doc = flattenHeads(heads);
+        done(null, doc);
+      });
+    }
+  });
+}
+
+function getObservationsBySurveyId(surveyId, observationsDb, cb) {
+  filterAllDocuments(observationsDb, match, cb);
+
+  function match(doc) {
+    return (
+      doc.tags &&
+      doc.tags.surveyId &&
+      doc.tags.surveyId.toString() === surveyId.toString()
+    );
+  }
+}
+
+function getObservationsByDeviceId(deviceId, observationsDb, cb) {
+  filterAllDocuments(observationsDb, match, cb);
+
+  function match(doc) {
+    return (
+      doc.tags &&
+      doc.tags.deviceId &&
+      doc.tags.deviceId.toString() === deviceId.toString()
+    );
+  }
+}
+
+function filterAllDocuments(observationsDb, filterFn, cb) {
+  var q = observationsDb.queryStream([[-90, 90], [-180, 180]]);
+  var t = through.obj(write);
+  var sink = concat({ encoding: "object" }, onValues);
+
+  q.pipe(t).pipe(sink);
+
+  function onValues(values) {
+    cb(null, values);
+  }
+
+  function write(doc, _, next) {
+    if (filterFn(doc)) {
+      this.push(doc);
+    }
+    next();
+  }
+}
+
+function flattenHeads(heads) {
+  var keys = Object.keys(heads);
+  if (keys.length === 0) return null;
+  return values(heads).sort(cmpFork)[0];
+}
+
+function values(obj) {
+  return Object.keys(obj).map(k => obj[k]);
+}
+
+/**
+ * Sort function to sort forks by most recent first, or by version id
+ * if no timestamps are set
+ */
+function cmpFork(a, b) {
+  if (a.timestamp && b.timestamp) {
+    if (a.timestamp > b.timestamp) return -1;
+    if (a.timestamp < b.timestamp) return 1;
+    return 0;
+  }
+  if (a.timestamp) return -1;
+  if (b.timestamp) return 1;
+  // Ensure sorting is stable between requests
+  return a.version < b.version ? -1 : 1;
+}

--- a/package.json
+++ b/package.json
@@ -15,11 +15,13 @@
   },
   "dependencies": {
     "JSONStream": "^1.3.1",
+    "async": "^2.5.0",
     "asyncstorage-down": "sethvincent/asyncstorage-down",
     "babel-plugin-rewrite-require": "^1.9.1",
     "bonjour": "github:noffle/bonjour",
     "buffer": "^5.0.6",
     "collect-stream": "^1.2.1",
+    "concat-stream": "^1.6.0",
     "d64": "^1.0.0",
     "data-uri-to-buffer": "^1.0.0",
     "end-of-stream": "^1.4.0",

--- a/test/create-observation.js
+++ b/test/create-observation.js
@@ -11,7 +11,6 @@ test("create an observation to a placeholder node, and check they are linked", f
 
   var obsDb = osmdb();
   var osm = osmp2p(obsDb, osmdb());
-  var linkDb = obsp2p({ db: memdb(), log: obsDb.log });
 
   var nodeId;
 

--- a/test/observations.js
+++ b/test/observations.js
@@ -1,0 +1,127 @@
+var test = require("tape");
+var osmdb = require("osm-p2p-mem");
+var obsdb = require("osm-p2p-observations");
+var memdb = require("memdb");
+var helpers = require("../app/lib/observations");
+var forEach = require("async").forEach;
+
+test("get observations by node", function(t) {
+  // Set up a new test db
+  var observationsDb = osmdb();
+  var observationsIndex = obsdb({ db: memdb(), log: observationsDb.log });
+
+  var docs = {
+    A: {
+      type: "observation",
+      lat: 1,
+      lon: 1
+    },
+    B: {
+      type: "observation",
+      lat: 2,
+      lon: 2
+    },
+    C: {
+      type: "observation-link",
+      link: "E",
+      obs: "A"
+    },
+    D: {
+      type: "observation-link",
+      link: "E",
+      obs: "B"
+    }
+  };
+
+  forEach(Object.keys(docs).sort(), insertDoc, checkObservations);
+
+  function insertDoc(docId, cb) {
+    observationsDb.put(docId, docs[docId], cb);
+  }
+
+  function checkObservations(err) {
+    t.error(err);
+
+    helpers.getObservationsByNode(
+      "E",
+      observationsDb,
+      observationsIndex,
+      function(err, res) {
+        t.error(err);
+        var expected = [
+          { lat: 1, lon: 1, type: "observation" },
+          { lat: 2, lon: 2, type: "observation" }
+        ];
+        t.deepEqual(res, expected);
+        t.end();
+      }
+    );
+  }
+});
+
+test("get observations by survey id, device id", function(t) {
+  // Set up a new test db
+  var observationsDb = osmdb();
+
+  var docs = {
+    A: {
+      type: "observation",
+      lat: 1,
+      lon: 1,
+      tags: {
+        surveyId: "123",
+        deviceId: "dead"
+      }
+    },
+    B: {
+      type: "observation",
+      lat: 2,
+      lon: 2,
+      tags: {
+        surveyId: "200",
+        deviceId: "beef"
+      }
+    },
+    C: {
+      type: "observation",
+      lat: 3,
+      lon: 3
+    }
+  };
+
+  forEach(Object.keys(docs).sort(), insertDoc, checkObservations);
+
+  function insertDoc(docId, cb) {
+    observationsDb.put(docId, docs[docId], cb);
+  }
+
+  function checkObservations(err) {
+    t.error(err);
+
+    helpers.getObservationsBySurveyId("123", observationsDb, function(
+      err,
+      res
+    ) {
+      t.error(err);
+      t.equal(res.length, 1);
+      var expected = [docs.A];
+      delete res[0].version;
+      delete res[0].id;
+      t.deepEqual(res, expected);
+
+      helpers.getObservationsByDeviceId("beef", observationsDb, function(
+        err,
+        res
+      ) {
+        t.error(err);
+        t.equal(res.length, 1);
+        var expected = [docs.B];
+        delete res[0].version;
+        delete res[0].id;
+        t.deepEqual(res, expected);
+
+        t.end();
+      });
+    });
+  }
+});


### PR DESCRIPTION
Adds some helper functions and tests for getting observations by

- Node ID
- Survey ID
- Device ID

It's super easy to add more: just define a new `matchFn` predicate to match on!