### PR TITLE
Update build tools

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,6 +143,8 @@ dependencies {
     compile "com.facebook.react:react-native:+"  // From node_modules
     compile project(':reactnativemapboxgl')
     compile project(':react-native-localization')
+    compile 'com.facebook.stetho:stetho:+'
+    compile 'com.facebook.stetho:stetho-okhttp3:+'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -91,7 +91,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "26.0.1"
 
     defaultConfig {
         applicationId "com.surveyor"

--- a/android/app/src/main/java/com/surveyor/MainApplication.java
+++ b/android/app/src/main/java/com/surveyor/MainApplication.java
@@ -9,10 +9,17 @@ import com.tradle.react.UdpSocketsModule;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
+import com.facebook.react.modules.network.OkHttpClientProvider;
+import com.facebook.react.modules.network.ReactCookieJarContainer;
 import com.facebook.react.modules.storage.ReactDatabaseSupplier;
 import com.facebook.soloader.SoLoader;
+import com.facebook.stetho.okhttp3.StethoInterceptor;
+import com.facebook.stetho.Stetho;
+
+import okhttp3.OkHttpClient;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.List;
 
 import com.wix.interactable.Interactable;
@@ -54,5 +61,15 @@ public class MainApplication extends Application implements ReactApplication {
     long size = 50L * 1024L * 1024L; // 50 MB
     ReactDatabaseSupplier.getInstance(getApplicationContext()).setMaximumSize(size);
     SoLoader.init(this, /* native exopackage */ false);
+
+    Stetho.initializeWithDefaults(this);
+    OkHttpClient client = new OkHttpClient.Builder()
+      .connectTimeout(0, TimeUnit.MILLISECONDS)
+      .readTimeout(0, TimeUnit.MILLISECONDS)
+      .writeTimeout(0, TimeUnit.MILLISECONDS)
+      .cookieJar(new ReactCookieJarContainer())
+      .addNetworkInterceptor(new StethoInterceptor())
+      .build();
+    OkHttpClientProvider.replaceOkHttpClient(client);
   }
 }


### PR DESCRIPTION
Stetho provides native view inspection:

![image](https://user-images.githubusercontent.com/45/28589652-df390810-7133-11e7-83cd-ad6c5b800307.png)

![image](https://user-images.githubusercontent.com/45/28589655-e2a106f6-7133-11e7-90ed-208f8cdcdeb3.png)

as well as inspection of network traffic:

![image](https://user-images.githubusercontent.com/45/28589691-015f5d04-7134-11e7-8353-1fb8709b4348.png)

without using the "Debug JS Remotely" option that seems to slow things down (by executing much JS within Chrome).

I was hoping that it would bridge `console.log` output, but I haven't figured out how to do that (adding `stetho-js-rhino` as a Gradle dep doesn't work--I think that's intended for native apps).

If after updating with these changes the app crashes on startup or reload, uninstall it from your [virtual] device and re-run `yarn run android`.