### PR TITLE
Handle observations on OSM.org nodes that used to be osm-p2p nodes

### DIFF
--- a/test/create-observation.js
+++ b/test/create-observation.js
@@ -66,20 +66,23 @@ test("create an observation to a pre-existing OSM.org node, and check they are l
   var doc = {
     type: "node",
     lat: 5,
-    lon: -5
+    lon: -5,
+    tags: {
+      'osm-p2p-id': 567
+    }
   };
-  osmOrgDb.create(JSON.stringify(doc), function(err, nodeId) {
+  osmOrgDb.create(doc, function(err, nodeId) {
     t.error(err);
 
-    var obs = JSON.stringify({
+    var obs = {
       type: "observation",
       lat: 6,
       lon: -6
-    });
+    };
     osm.createObservation(nodeId, obs, function(err, obsDoc, linkDoc) {
       t.error(err);
       t.equals(linkDoc.obs, obsDoc.id);
-      t.equals(linkDoc.link, nodeId);
+      t.equals(linkDoc.link, 567);
     });
   });
 });

--- a/test/create-observation.js
+++ b/test/create-observation.js
@@ -20,21 +20,21 @@ test("create an observation to a placeholder node, and check they are linked", f
 
   var nodeId;
 
-  var node = JSON.stringify({
+  var node = {
     type: "node",
     lat: 5,
     lon: -5
-  });
+  };
   osm.createNode(node, function(err, node) {
     t.error(err);
     var doc = node.value.v;
     nodeId = node.value.k;
 
-    var obs = JSON.stringify({
+    var obs = {
       type: "observation",
       lat: 6,
       lon: -6
-    });
+    };
     osm.createObservation(doc.tags["osm-p2p-id"], obs, function(
       err,
       obsDoc,
@@ -68,7 +68,7 @@ test("create an observation to a pre-existing OSM.org node, and check they are l
     lat: 5,
     lon: -5,
     tags: {
-      'osm-p2p-id': 567
+      "osm-p2p-id": 567
     }
   };
   osmOrgDb.create(doc, function(err, nodeId) {
@@ -132,14 +132,12 @@ test("simulate an observation created before & after a placeholder node becomes 
 
   // step 1
   function createPlaceholderNodeAndObservation(done) {
-    var node = JSON.stringify(doc);
-    osm.createNode(node, function(err, node) {
+    osm.createNode(doc, function(err, node) {
       t.error(err);
       var newDoc = node.value.v;
       p2pId = node.value.k;
 
-      var observation = JSON.stringify(obs);
-      osm.createObservation(newDoc.tags["osm-p2p-id"], observation, function(
+      osm.createObservation(newDoc.tags["osm-p2p-id"], obs, function(
         err,
         obsDoc,
         _linkDoc
@@ -156,7 +154,7 @@ test("simulate an observation created before & after a placeholder node becomes 
   // step 2
   function createOsmOrgNode(done) {
     var newDoc = Object.assign(doc, { tags: { "osm-p2p-id": p2pId } });
-    osmOrgDb.create(JSON.stringify(newDoc), function(err, _osmId) {
+    osmOrgDb.create(newDoc, function(err, _osmId) {
       t.error(err);
       osmId = _osmId;
       done();


### PR DESCRIPTION
This is for the case where we've created a placeholder node in the ObservationsDB, which then gets exported to OSM.org by the Coordinator later, and then comes back to the Collector via sync some time in the future. Any new observations on that node should link to `doc.tags['osm-p2p-id']` instead of `doc.id` so that observation links remain consistent.

Addresses the remaining piece of #101.