### PR TITLE
Drop pin to add point to map

### DIFF
--- a/app/components/map.js
+++ b/app/components/map.js
@@ -1,5 +1,6 @@
+import debounce from "debounce";
 import React, { Component } from "react";
-import { StyleSheet, View, ListView, TouchableOpacity } from "react-native";
+import { View } from "react-native";
 import Mapbox, { MapView } from "react-native-mapbox-gl";
 import Icon from "react-native-vector-icons/MaterialIcons";
 
@@ -30,10 +31,22 @@ class Map extends Component {
   };
 
   render() {
-    const { observation, geolocateIcon, newPointPin, center } = this.props;
+    const {
+      center,
+      geolocateIcon,
+      newPointPin,
+      onRegionDidChange
+    } = this.props;
 
     const optional = {};
-    if (center) optional.initialCenterCoordinate = center;
+
+    if (center) {
+      optional.initialCenterCoordinate = center;
+    }
+
+    if (onRegionDidChange) {
+      optional.onRegionDidChange = debounce(onRegionDidChange, 400);
+    }
 
     return (
       <View style={{ height: this.props.height || 100 }}>

--- a/app/screens/Observation/map.js
+++ b/app/screens/Observation/map.js
@@ -9,6 +9,7 @@ import {
   selectActiveSurveys,
   selectLoadingStatus,
   selectIsQuerying,
+  selectSelectedBounds,
   selectSelectedFeatures,
   selectVisibleFeatures,
   selectVisibleObservations
@@ -83,10 +84,14 @@ class ObservationMapScreen extends Component {
 
   componentWillUpdate(nextProps, nextState) {
     const { history } = this.props;
-    const { selectedFeatures } = nextProps;
+    const { selectedBounds, selectedFeatures } = nextProps;
 
     if (selectedFeatures.length > 0) {
-      history.push("/observation/choose-point");
+      return history.push("/observation/choose-point");
+    }
+
+    if (selectedBounds !== null) {
+      return history.push("/observation/choose-point");
     }
   }
 
@@ -291,6 +296,7 @@ const mapStateToProps = state => ({
   loading: selectLoadingStatus(state),
   observations: selectVisibleObservations(state),
   querying: selectIsQuerying(state),
+  selectedBounds: selectSelectedBounds(state),
   selectedFeatures: selectSelectedFeatures(state)
 });
 


### PR DESCRIPTION
When tapping unpopulated areas of the map, choose-point uses the selected bounds to initialize the map. That map can be panned to adjust the observation point (there's lag here), which will always be in the center of the map. "Add to a new point" will use this to create the new observation.