### PR TITLE
Feature/242 observation completeness

### DIFF
--- a/app/lib/calculate-completeness.js
+++ b/app/lib/calculate-completeness.js
@@ -1,24 +1,37 @@
-function pickSurvey(surveyFields, observation) {
+/**
+ * Given fields from all surveys return the survey fields
+ * pertaining to the observation's type
+ * 
+ * @param {Array} allSurveyFields 
+ * @param {Object} observation 
+ * @return {Array}
+ */
+function pickSurvey(allSurveyFields, observation) {
   const surveyType = observation.tags.surveyType;
-  for (let i = 0; i < surveyFields.length; i++) {
-    if (surveyFields[i].id === surveyType) {
-      return surveyFields[i];
+  for (let i = 0; i < allSurveyFields.length; i++) {
+    if (allSurveyFields[i].id === surveyType) {
+      return allSurveyFields[i].fields;
     }
   }
 }
+
 /**
- * Given the list of active survey fields and an observation, calculate the percent
- * completeness and attach it to the observation
+ * Given a survey's fields and an observation, calculate the percent
+ * completeness and return the number between 0 and 100
  * 
  * @param {Array} surveys
  * @param {Object} observation 
  * @returns {Float} = {0..100}
  */
-function calculateCompleteness(fields, observation) {
-  const surveyFields = pickSurvey(fields, observation).fields;
+function calculateCompleteness(surveyFields, observation) {
+  if (!surveyFields || !observation) return 0;
+
   const keys = new Set(surveyFields.map(field => field.key));
   let filledTags = Object.keys(observation.tags).filter(tag => keys.has(tag));
   return parseInt(filledTags.length / keys.size * 100, 10);
 }
 
-module.exports = calculateCompleteness;
+module.exports = {
+  calculateCompleteness,
+  pickSurvey
+};

--- a/app/lib/calculate-completeness.js
+++ b/app/lib/calculate-completeness.js
@@ -1,0 +1,24 @@
+function pickSurvey(surveyFields, observation) {
+  const surveyType = observation.tags.surveyType;
+  for (let i = 0; i < surveyFields.length; i++) {
+    if (surveyFields[i].id === surveyType) {
+      return surveyFields[i];
+    }
+  }
+}
+/**
+ * Given the list of active survey fields and an observation, calculate the percent
+ * completeness and attach it to the observation
+ * 
+ * @param {Array} surveys
+ * @param {Object} observation 
+ * @returns {Float} = {0..100}
+ */
+function calculateCompleteness(fields, observation) {
+  const surveyFields = pickSurvey(fields, observation).fields;
+  const keys = new Set(surveyFields.map(field => field.key));
+  let filledTags = Object.keys(observation.tags).filter(tag => keys.has(tag));
+  return parseInt(filledTags.length / keys.size * 100, 10);
+}
+
+module.exports = calculateCompleteness;

--- a/app/screens/Account/observations.js
+++ b/app/screens/Account/observations.js
@@ -6,7 +6,10 @@ import { connect } from "react-redux";
 import { format } from "date-fns";
 import { Link } from "react-router-native";
 
-import calculateCompleteness from "../../lib/calculate-completeness";
+import {
+  pickSurvey,
+  calculateCompleteness
+} from "../../lib/calculate-completeness";
 
 import {
   syncData,
@@ -36,7 +39,8 @@ class AccountObservations extends Component {
 
     osm.getObservationsByDeviceId(deviceId, (err, results) => {
       let resultsWithCompleteness = results.map(result => {
-        let percentage = calculateCompleteness(types, result);
+        let survey = pickSurvey(types, result);
+        let percentage = calculateCompleteness(survey, result);
         result.percentage = percentage;
         return result;
       });

--- a/app/screens/Observation/view.js
+++ b/app/screens/Observation/view.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import Icon from "react-native-vector-icons/MaterialIcons";
 import { Link } from "react-router-native";
 
+import { calculateCompleteness } from "../../lib/calculate-completeness";
 import { saveObservation, updateObservation } from "../../actions";
 import {
   Text,
@@ -11,7 +12,8 @@ import {
   Map,
   LocationModal,
   ObservationTypeModal,
-  AnnotationObservation
+  AnnotationObservation,
+  PercentComplete
 } from "../../components";
 import { getFieldType } from "../../components/fields";
 import {
@@ -187,6 +189,10 @@ class ViewObservationScreen extends Component {
       return null;
     }
 
+    const percent = calculateCompleteness(fields, observation);
+    const complete = parseInt(percent / 10, 10);
+    const incomplete = 10 - complete;
+
     const { locationModalOpen, observationTypeModalOpen } = this.state;
 
     const headerView = (
@@ -211,6 +217,20 @@ class ViewObservationScreen extends Component {
 
     return (
       <Wrapper style={[baseStyles.wrapper]} headerView={headerView}>
+        {fields /* Don't render if we don't have a survey type yet */
+          ? <PercentComplete
+              radius={35}
+              complete={complete}
+              incomplete={incomplete}
+            >
+              <Text style={[baseStyles.percentCompleteTextSm]}>
+                <Text style={[baseStyles.percentCompleteTextNumSm]}>
+                  {percent + "%"}
+                </Text>
+              </Text>
+            </PercentComplete>
+          : <View />}
+
         {locationModalOpen &&
           <LocationModal
             close={this.closeLocationModal}

--- a/app/screens/OsmFeature/view.js
+++ b/app/screens/OsmFeature/view.js
@@ -179,7 +179,7 @@ class ViewOsmFeature extends Component {
                   Updated: {format(obs.timestamp, "h:mm aa ddd, MMM D, YYYY")}
                 </Text>
                 <Text style={{ fontSize: 12 }}>
-                  Completeness: {percent + "%"}
+                  {percent + "%"} complete.
                 </Text>
               </View>
               <View>

--- a/app/screens/OsmFeature/view.js
+++ b/app/screens/OsmFeature/view.js
@@ -13,7 +13,11 @@ import { format } from "date-fns";
 
 import { initializeObservation, setActiveObservation } from "../../actions";
 import { Text, Wrapper, Map, AnnotationOSM } from "../../components";
-import { selectFeatureType } from "../../selectors";
+import {
+  pickSurvey,
+  calculateCompleteness
+} from "../../lib/calculate-completeness";
+import { selectFeatureTypes } from "../../selectors";
 import { baseStyles } from "../../styles";
 
 const Screen = Dimensions.get("window");
@@ -144,7 +148,7 @@ class ViewOsmFeature extends Component {
   };
 
   renderObservations = () => {
-    const { history, location, setActiveObservation } = this.props;
+    const { history, location, setActiveObservation, types } = this.props;
     const { feature: { observations } } = location.state;
     let observationList;
 
@@ -154,6 +158,8 @@ class ViewOsmFeature extends Component {
         const surveyType = obs.tags.surveyType;
 
         console.log("obs", obs);
+        const survey = pickSurvey(types, obs);
+        const percent = calculateCompleteness(survey, obs);
 
         return (
           <TouchableOpacity
@@ -171,6 +177,9 @@ class ViewOsmFeature extends Component {
                 <Text style={[baseStyles.fieldValue]}>Observation</Text>
                 <Text style={{ fontSize: 12 }}>
                   Updated: {format(obs.timestamp, "h:mm aa ddd, MMM D, YYYY")}
+                </Text>
+                <Text style={{ fontSize: 12 }}>
+                  Completeness: {percent + "%"}
                 </Text>
               </View>
               <View>
@@ -203,7 +212,9 @@ class ViewOsmFeature extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  return {};
+  return {
+    types: selectFeatureTypes(state)
+  };
 };
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
This adds completeness to the following views:

**My observations**
![android emulator - nexus_5x_api_22 5554 2017-09-12 18-23-13](https://user-images.githubusercontent.com/719357/30351043-7cc081f6-97e7-11e7-8593-e2492780483d.png)

**Observation view**
![android emulator - nexus_5x_api_22 5554 2017-09-12 18-24-27](https://user-images.githubusercontent.com/719357/30351074-a41fe764-97e7-11e7-9a56-c5117b658ce5.png)

**OSM feature view**
![android emulator - nexus_5x_api_22 5554 2017-09-12 18-25-39](https://user-images.githubusercontent.com/719357/30351110-d0b25be0-97e7-11e7-97cb-6007840483ab.png)

Thanks @sethvincent for the nice PercentComplete component! 
I'm not sure if this method of calculating completeness (on every render) will scale with many points in "My observations". We might need to find a way to save completeness as a tag, but that would be tying the survey fields to the observations; right now they're pretty decoupled (which I think is better in case a survey changes its fields). What do you think?