### PR TITLE
allow fallback coordinator address

### DIFF
--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -7,11 +7,17 @@ const initialState = {
   remoteSurveyFetched: null,
   syncingSurveyData: null,
   surveyDataSynced: null,
+  fetchingListFailed: null,
+  mdnsConnectionFailed: null,
+  manualConnectionFailed: null,
   available: [],
   remote: []
 };
 
-export default (state = initialState, { id, survey, surveys, type }) => {
+export default (
+  state = initialState,
+  { id, survey, surveys, type, failedConnectionType }
+) => {
   switch (type) {
     case types.CLEAR_LOCAL_SURVEYS:
       return {
@@ -44,7 +50,10 @@ export default (state = initialState, { id, survey, surveys, type }) => {
     case types.FETCHING_REMOTE_SURVEY_LIST_FAILED:
       return {
         ...state,
-        remote: []
+        remote: [],
+        fetchingListFailed: true,
+        mdnsConnectionFailed: failedConnectionType === "mdns",
+        manualConnectionFailed: failedConnectionType === "manual"
       };
 
     case types.RECEIVED_REMOTE_SURVEY:
@@ -62,7 +71,10 @@ export default (state = initialState, { id, survey, surveys, type }) => {
     case types.RECEIVED_REMOTE_SURVEY_LIST:
       return {
         ...state,
-        remote: surveys
+        remote: surveys,
+        fetchingListFailed: null,
+        mdnsConnectionFailed: null,
+        manualConnectionFailed: null
       };
 
     case types.SYNCING_SURVEY_DATA:

--- a/app/screens/Account/RemoteSurveyList.js
+++ b/app/screens/Account/RemoteSurveyList.js
@@ -4,7 +4,8 @@ import {
   View,
   Dimensions,
   ActivityIndicator,
-  ScrollView
+  ScrollView,
+  TextInput
 } from "react-native";
 import Icon from "react-native-vector-icons/MaterialIcons";
 
@@ -24,12 +25,49 @@ export default class RemoteSurveyList extends Component {
     });
   };
 
+  onAddressInput = address => {
+    this.setState({ address });
+  };
+
+  onAddressSubmit = e => {
+    this.props.listRemoteSurveys(this.state.address);
+  };
+
+  componentWillMount() {
+    this.setState({
+      address: "http://10.0.2.2:3211"
+    });
+  }
+
   render() {
-    const { fetch, surveys, sync, close } = this.props;
+    const { fetch, surveys, sync, close, fetchingListFailed } = this.props;
+
+    if (fetchingListFailed) {
+      return (
+        <View style={baseStyles.wrapperContentMdInterior}>
+          <Text style={baseStyles.h3}>Connect Manually</Text>
+          <Text>Enter the full address of the Observe desktop app</Text>
+          <TextInput
+            ref={view => (this.addressInput = view)}
+            onSubmitEditing={this.onAddressSubmit}
+            onChangeText={this.onAddressInput}
+            value={this.state.address}
+            underlineColorAndroid="#ccc"
+            autoFocus
+          />
+          <TouchableOpacity
+            onPress={this.onAddressSubmit}
+            style={baseStyles.buttonContent}
+          >
+            <Text style={{ color: "white" }}>Get survey list</Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
 
     if (surveys == null || surveys.length === 0) {
       return (
-        <View style={[baseStyles.wrapperContentMdInterior]}>
+        <View style={baseStyles.wrapperContentMdInterior}>
           <ActivityIndicator
             style={{ marginTop: 50, marginBottom: 20 }}
             animating

--- a/app/screens/Account/SurveyModal.js
+++ b/app/screens/Account/SurveyModal.js
@@ -18,7 +18,7 @@ import { baseStyles } from "../../styles";
 class SurveyModal extends Component {
   componentWillMount() {
     this.props.clearRemoteSurveys();
-    this.props.listRemoteSurveys();
+    if (!this.props.mdnsConnectionFailed) this.props.listRemoteSurveys();
   }
 
   render() {
@@ -29,9 +29,11 @@ class SurveyModal extends Component {
       activeSurveys,
       syncData,
       fetchingRemoteSurvey,
+      fetchingListFailed,
       remoteSurveyFetched,
       syncingSurveyData,
-      surveyDataSynced
+      surveyDataSynced,
+      listRemoteSurveys
     } = this.props;
 
     const loadingSurvey = fetchingRemoteSurvey || syncingSurveyData;
@@ -61,6 +63,8 @@ class SurveyModal extends Component {
               surveys={remoteSurveys}
               activeSurveys={activeSurveys}
               close={close}
+              fetchingListFailed={fetchingListFailed}
+              listRemoteSurveys={listRemoteSurveys}
             />
 
             {loadingSurvey &&
@@ -78,17 +82,15 @@ class SurveyModal extends Component {
                 }}
               >
                 <View
-                  style={
-                    (
-                      [baseStyles.wrapperContentMdInterior],
-                      {
-                        backgroundColor: "white",
-                        elevation: 2,
-                        padding: 40,
-                        width: 200
-                      }
-                    )
-                  }
+                  style={[
+                    baseStyles.wrapperContentMdInterior,
+                    {
+                      backgroundColor: "white",
+                      elevation: 2,
+                      padding: 40,
+                      width: 200
+                    }
+                  ]}
                 >
                   <ActivityIndicator animating size="large" />
                   <Text style={{ textAlign: "center" }}>Loading survey</Text>
@@ -103,6 +105,9 @@ class SurveyModal extends Component {
 
 const mapStateToProps = state => ({
   fetchingRemoteSurvey: state.surveys.fetchingRemoteSurvey,
+  fetchingListFailed: state.surveys.fetchingListFailed,
+  mdnsConnectionFailed: state.surveys.mdnsConnectionFailed,
+  manualConnectionFailed: state.surveys.manualConnectionFailed,
   remoteSurveys: selectRemoteSurveys(state),
   activeSurveys: selectActiveSurveys(state)
 });


### PR DESCRIPTION
If mdns connection fails, this provides a fallback method of entering the address of the desktop app.

Along with this we probably need a way for an end user to see what the address is in the ui of the desktop app: https://github.com/osmlab/field-data-coordinator/issues/105

I ended up needing this just to debug the windows build.

Looks like this:

<img width="330" alt="screen shot 2017-09-14 at 8 04 06 pm" src="https://user-images.githubusercontent.com/164214/30460947-3eea0bde-9988-11e7-9a65-95dace164efc.png">
