### PR TITLE
[wip] #182 survey toggles

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -43,6 +43,7 @@ const types = {
   FETCHING_REMOTE_SURVEY_LIST: "FETCHING_REMOTE_SURVEY_LIST",
   FETCHING_REMOTE_SURVEY_LIST_FAILED: "FETCHING_REMOTE_SURVEY_LIST_FAILED",
   DELETE_LOCAL_SURVEY: "DELETE_LOCAL_SURVEY",
+  TOGGLE_SURVEY_ACTIVITY: "TOGGLE_SURVEY_ACTIVITY",
   INITIALIZE_OBSERVATION: "INITIALIZE_OBSERVATION",
   SET_ACTIVE_OBSERVATION: "SET_ACTIVE_OBSERVATION",
   RECEIVED_REMOTE_SURVEY_LIST: "RECEIVED_REMOTE_SURVEY_LIST",
@@ -270,6 +271,13 @@ export const syncData = target => (dispatch, getState) => {
       }
     }
   );
+};
+
+export const toggleSurveyActivity = surveyId => dispatch => {
+  dispatch({
+    type: types.TOGGLE_SURVEY_ACTIVITY,
+    id: surveyId
+  });
 };
 
 export const clearLocalSurveys = () => (dispatch, getState) =>

--- a/app/reducers/surveys.js
+++ b/app/reducers/surveys.js
@@ -11,6 +11,7 @@ const initialState = {
   mdnsConnectionFailed: null,
   manualConnectionFailed: null,
   available: [],
+  active: [],
   remote: []
 };
 
@@ -96,6 +97,26 @@ export default (
         ...state,
         available: state.available.filter(s => s.definition.id !== id)
       };
+
+    /**
+       * state.active is a list of survey ids
+       * that the user has toggled on in Account/Surveys
+       * 
+       */
+    case types.TOGGLE_SURVEY_ACTIVITY:
+      // Check if state.active contains the survey
+      let isActive = !!state.active.find(v => v === id);
+      if (isActive) {
+        return {
+          ...state,
+          active: state.active.filter(v => v !== id)
+        };
+      } else {
+        return {
+          ...state,
+          active: [...state.active, id]
+        };
+      }
 
     default:
       return state;

--- a/app/screens/Account/LocalSurveyList.js
+++ b/app/screens/Account/LocalSurveyList.js
@@ -82,7 +82,8 @@ class LocalSurveyList extends Component {
                     value={survey.active}
                     disabled={survey.active && disableToggle} // Only disable active surveys
                     onValueChange={() => {
-                      toggleSurveyActivity(survey.definition.id);
+                      let { name, id } = survey.definition;
+                      toggleSurveyActivity(name || id);
                     }}
                   />
                 </View>

--- a/app/screens/Account/LocalSurveyList.js
+++ b/app/screens/Account/LocalSurveyList.js
@@ -54,7 +54,7 @@ class LocalSurveyList extends Component {
             : 0;
 
           return (
-            <Link to={`/account/surveys/${survey.definition.name}`}>
+            <View>
               <View
                 key={idx}
                 style={[
@@ -72,11 +72,13 @@ class LocalSurveyList extends Component {
                     }
                   ]}
                 >
-                  <Text
-                    style={[baseStyles.h3, baseStyles.headerWithDescription]}
-                  >
-                    {survey.definition.name}
-                  </Text>
+                  <Link to={`/account/surveys/${survey.definition.name}`}>
+                    <Text
+                      style={[baseStyles.h3, baseStyles.headerWithDescription]}
+                    >
+                      {survey.definition.name}
+                    </Text>
+                  </Link>
 
                   <Switch
                     value={survey.active}
@@ -92,8 +94,11 @@ class LocalSurveyList extends Component {
                     {observationCount} Observations
                   </Text>
                 </View>
+                <Link to={`/account/surveys/${survey.definition.name}`}>
+                  <Text>Edit</Text>
+                </Link>
               </View>
-            </Link>
+            </View>
           );
         })}
       </View>

--- a/app/screens/Account/LocalSurveyList.js
+++ b/app/screens/Account/LocalSurveyList.js
@@ -10,6 +10,16 @@ import { selectActiveSurveyIds } from "../../selectors";
 import { Text } from "../../components";
 import { baseStyles } from "../../styles";
 
+/* Switch background */
+const ON_COLOR_DISABLED = "#CCE1D1";
+const ON_COLOR = "#B2DFDB";
+const OFF_COLOR = "#B2B2B2";
+
+/* Switch thumb */
+const ON_COLOR_DISABLED_THUMB = "#90C7A2";
+const ON_COLOR_THUMB = "#009388";
+const OFF_COLOR_THUMB = "#ECECEC";
+
 class LocalSurveyList extends Component {
   componentWillMount() {
     const { surveys } = this.props;
@@ -41,6 +51,7 @@ class LocalSurveyList extends Component {
     // We want to disable the toggles if there is only one
     // active id left
     let disableToggle = activeIds.length <= 1;
+    const onTintColor = disableToggle ? ON_COLOR_DISABLED : ON_COLOR;
 
     if (surveys == null || surveys.length === 0) {
       return null;
@@ -49,6 +60,15 @@ class LocalSurveyList extends Component {
     return (
       <View style={{}}>
         {surveys.map((survey, idx) => {
+          let thumbTintColor = ON_COLOR_THUMB;
+          if (survey.active) {
+            thumbTintColor = disableToggle
+              ? ON_COLOR_DISABLED_THUMB
+              : ON_COLOR_THUMB;
+          } else {
+            thumbTintColor = OFF_COLOR_THUMB;
+          }
+
           const observationCount = this.state.surveys[survey.definition.name]
             ? this.state.surveys[survey.definition.name].observations.length
             : 0;
@@ -81,6 +101,9 @@ class LocalSurveyList extends Component {
                   </Link>
 
                   <Switch
+                    onTintColor={onTintColor}
+                    tintColor={OFF_COLOR}
+                    thumbTintColor={thumbTintColor}
                     value={survey.active}
                     disabled={survey.active && disableToggle} // Only disable active surveys
                     onValueChange={() => {

--- a/app/screens/Account/LocalSurveyList.js
+++ b/app/screens/Account/LocalSurveyList.js
@@ -11,13 +11,13 @@ import { Text } from "../../components";
 import { baseStyles } from "../../styles";
 
 /* Switch background */
-const ON_COLOR_DISABLED = "#CCE1D1";
-const ON_COLOR = "#B2DFDB";
+const ON_COLOR_DISABLED = "#CAFAEE";
+const ON_COLOR = "#1DE9B6";
 const OFF_COLOR = "#B2B2B2";
 
 /* Switch thumb */
-const ON_COLOR_DISABLED_THUMB = "#90C7A2";
-const ON_COLOR_THUMB = "#009388";
+const ON_COLOR_DISABLED_THUMB = "#F5F7F7";
+const ON_COLOR_THUMB = "#ffffff";
 const OFF_COLOR_THUMB = "#ECECEC";
 
 class LocalSurveyList extends Component {
@@ -94,7 +94,11 @@ class LocalSurveyList extends Component {
                 >
                   <Link to={`/account/surveys/${survey.definition.name}`}>
                     <Text
-                      style={[baseStyles.h3, baseStyles.headerWithDescription]}
+                      style={[
+                        baseStyles.h3,
+                        baseStyles.headerWithDescription,
+                        baseStyles.headerLink
+                      ]}
                     >
                       {survey.definition.name}
                     </Text>
@@ -117,8 +121,11 @@ class LocalSurveyList extends Component {
                     {observationCount} Observations
                   </Text>
                 </View>
-                <Link to={`/account/surveys/${survey.definition.name}`}>
-                  <Text>Edit</Text>
+                <Link
+                  style={{ marginTop: 10 }}
+                  to={`/account/surveys/${survey.definition.name}`}
+                >
+                  <Text style={[baseStyles.link]}>Edit</Text>
                 </Link>
               </View>
             </View>

--- a/app/screens/Account/LocalSurveyList.js
+++ b/app/screens/Account/LocalSurveyList.js
@@ -1,12 +1,11 @@
 import React, { Component } from "react";
-import { View, Alert } from "react-native";
+import { View, Switch } from "react-native";
 import { connect } from "react-redux";
-import Icon from "react-native-vector-icons/MaterialIcons";
 import { Link } from "react-router-native";
+import { toggleSurveyActivity } from "../../actions";
 
 import { osm } from "../../actions";
 
-import { deleteLocalSurvey } from "../../actions";
 import { Text } from "../../components";
 import { baseStyles } from "../../styles";
 
@@ -36,7 +35,7 @@ class LocalSurveyList extends Component {
   }
 
   render() {
-    const { surveys, deleteLocalSurvey } = this.props;
+    const { surveys, toggleSurveyActivity } = this.props;
 
     if (surveys == null || surveys.length === 0) {
       return null;
@@ -74,26 +73,10 @@ class LocalSurveyList extends Component {
                     {survey.definition.name}
                   </Text>
 
-                  <Icon
-                    name="delete"
-                    style={[[baseStyles.headerBackIcon]]}
-                    onPress={() => {
-                      Alert.alert(
-                        `Delete ${survey.definition.name}?`,
-                        "This will remove the survey from your phone, but not your observations",
-                        [
-                          {
-                            text: "Cancel",
-                            onPress: () => console.log("Cancel Pressed"),
-                            style: "cancel"
-                          },
-                          {
-                            text: "Delete survey",
-                            onPress: () =>
-                              deleteLocalSurvey(survey.definition.id)
-                          }
-                        ]
-                      );
+                  <Switch
+                    value={survey.active}
+                    onValueChange={() => {
+                      toggleSurveyActivity(survey.definition.id);
                     }}
                   />
                 </View>
@@ -115,4 +98,6 @@ const mapStateToProps = state => {
   return {};
 };
 
-export default connect(mapStateToProps, { deleteLocalSurvey })(LocalSurveyList);
+export default connect(mapStateToProps, { toggleSurveyActivity })(
+  LocalSurveyList
+);

--- a/app/screens/Account/LocalSurveyList.js
+++ b/app/screens/Account/LocalSurveyList.js
@@ -5,6 +5,7 @@ import { Link } from "react-router-native";
 import { toggleSurveyActivity } from "../../actions";
 
 import { osm } from "../../actions";
+import { selectActiveSurveyIds } from "../../selectors";
 
 import { Text } from "../../components";
 import { baseStyles } from "../../styles";
@@ -35,7 +36,11 @@ class LocalSurveyList extends Component {
   }
 
   render() {
-    const { surveys, toggleSurveyActivity } = this.props;
+    const { surveys, toggleSurveyActivity, activeIds } = this.props;
+
+    // We want to disable the toggles if there is only one
+    // active id left
+    let disableToggle = activeIds.length <= 1;
 
     if (surveys == null || surveys.length === 0) {
       return null;
@@ -75,6 +80,7 @@ class LocalSurveyList extends Component {
 
                   <Switch
                     value={survey.active}
+                    disabled={survey.active && disableToggle} // Only disable active surveys
                     onValueChange={() => {
                       toggleSurveyActivity(survey.definition.id);
                     }}
@@ -95,7 +101,9 @@ class LocalSurveyList extends Component {
 }
 
 const mapStateToProps = state => {
-  return {};
+  return {
+    activeIds: selectActiveSurveyIds(state).filter(x => x) // filter out null ids
+  };
 };
 
 export default connect(mapStateToProps, { toggleSurveyActivity })(

--- a/app/screens/Account/RemoteSurveyList.js
+++ b/app/screens/Account/RemoteSurveyList.js
@@ -15,14 +15,11 @@ import { baseStyles } from "../../styles";
 const Screen = Dimensions.get("window");
 
 export default class RemoteSurveyList extends Component {
-  isActive = survey => {
-    const { activeSurveys } = this.props;
+  isAvailable = survey => {
+    const { availableSurveys } = this.props;
 
     // TODO: check version of survey
-    return !!activeSurveys.find(s => {
-      console.log(s.definition.name, survey.name);
-      return s.definition.name === survey.name;
-    });
+    return !!availableSurveys.find(s => s.definition.name === survey.name);
   };
 
   onAddressInput = address => {
@@ -88,13 +85,13 @@ export default class RemoteSurveyList extends Component {
           }}
         >
           {surveys.map((survey, idx) => {
-            const active = this.isActive(survey);
+            const available = this.isAvailable(survey);
 
             return (
               <TouchableOpacity
                 key={idx}
                 onPress={() => {
-                  if (active) return;
+                  if (available) return;
 
                   fetch(survey.id, survey.url);
                   sync(survey.target);
@@ -105,7 +102,7 @@ export default class RemoteSurveyList extends Component {
                   {survey.name} {survey.version}
                 </Text>
 
-                {active &&
+                {available &&
                   <View
                     style={{
                       flex: 1,

--- a/app/screens/Account/SurveyModal.js
+++ b/app/screens/Account/SurveyModal.js
@@ -12,7 +12,7 @@ import {
 } from "../../actions";
 import { StatusBar, Text } from "../../components";
 import RemoteSurveyList from "./RemoteSurveyList";
-import { selectRemoteSurveys, selectActiveSurveys } from "../../selectors";
+import { selectRemoteSurveys, selectAvailableSurveys } from "../../selectors";
 import { baseStyles } from "../../styles";
 
 class SurveyModal extends Component {
@@ -26,7 +26,7 @@ class SurveyModal extends Component {
       close,
       fetchRemoteSurvey,
       remoteSurveys,
-      activeSurveys,
+      availableSurveys,
       syncData,
       fetchingRemoteSurvey,
       fetchingListFailed,
@@ -61,7 +61,7 @@ class SurveyModal extends Component {
               fetch={fetchRemoteSurvey}
               sync={syncData}
               surveys={remoteSurveys}
-              activeSurveys={activeSurveys}
+              availableSurveys={availableSurveys}
               close={close}
               fetchingListFailed={fetchingListFailed}
               listRemoteSurveys={listRemoteSurveys}
@@ -109,7 +109,7 @@ const mapStateToProps = state => ({
   mdnsConnectionFailed: state.surveys.mdnsConnectionFailed,
   manualConnectionFailed: state.surveys.manualConnectionFailed,
   remoteSurveys: selectRemoteSurveys(state),
-  activeSurveys: selectActiveSurveys(state)
+  availableSurveys: selectAvailableSurveys(state)
 });
 
 export default connect(mapStateToProps, {

--- a/app/screens/Account/survey.js
+++ b/app/screens/Account/survey.js
@@ -20,7 +20,7 @@ import {
 
 import { osm, setActiveObservation, deleteLocalSurvey } from "../../actions";
 
-import { selectActiveSurveys } from "../../selectors";
+import { selectAvailableSurveys } from "../../selectors";
 
 class SurveysScreen extends Component {
   componentWillMount() {
@@ -207,7 +207,7 @@ class SurveysScreen extends Component {
 
 const mapStateToProps = state => {
   return {
-    surveys: selectActiveSurveys(state)
+    surveys: selectAvailableSurveys(state)
   };
 };
 

--- a/app/screens/Account/survey.js
+++ b/app/screens/Account/survey.js
@@ -26,7 +26,8 @@ class SurveysScreen extends Component {
   componentWillMount() {
     const { surveys, match: { params: { surveyId } } } = this.props;
     let { definition: { featureTypes, id } } = surveys.find(survey => {
-      return survey && survey.definition && survey.definition.name === surveyId;
+      let { name, id } = survey.definition;
+      return surveyId === (name || id);
     });
 
     const ds = new ListView.DataSource({

--- a/app/screens/Account/surveys.js
+++ b/app/screens/Account/surveys.js
@@ -6,7 +6,7 @@ import { Link } from "react-router-native";
 
 import { clearLocalSurveys } from "../../actions";
 import { Text, Wrapper } from "../../components";
-import { selectAvailableSurveys } from "../../selectors";
+import { selectSurveysWithActivity } from "../../selectors";
 import { baseStyles } from "../../styles";
 import LocalSurveyList from "./LocalSurveyList";
 import SurveyModal from "./SurveyModal";
@@ -35,11 +35,12 @@ class SurveysScreen extends Component {
 
   componentWillMount() {
     const { availableSurveys } = this.props;
+    console.log(availableSurveys);
     if (!availableSurveys.length) this.showModal();
   }
 
   render() {
-    const { availableSurveys, history } = this.props;
+    const { availableSurveys } = this.props;
     const { showModal } = this.state;
 
     const headerView = (
@@ -95,7 +96,7 @@ class SurveysScreen extends Component {
 }
 
 const mapStateToProps = state => ({
-  availableSurveys: selectAvailableSurveys(state)
+  availableSurveys: selectSurveysWithActivity(state)
 });
 
 export default connect(mapStateToProps, { clearLocalSurveys })(SurveysScreen);

--- a/app/screens/Account/surveys.js
+++ b/app/screens/Account/surveys.js
@@ -72,13 +72,12 @@ class SurveysScreen extends Component {
           }}
           hideStatusBar
         >
-          {showModal && <SurveyModal close={this.hideModal} />}
-
-          <LocalSurveyList surveys={availableSurveys} />
           <Text style={[baseStyles.wrapperContent]}>
-            Choose which surveys to edit and show on the map. One survey has to
-            be active at any time.
+            Choose a survey you'd like to add observations to. Please note, at
+            leaset one survey has to be active at any time.
           </Text>
+          {showModal && <SurveyModal close={this.hideModal} />}
+          <LocalSurveyList surveys={availableSurveys} />
         </ScrollView>
         <View
           style={{

--- a/app/screens/Account/surveys.js
+++ b/app/screens/Account/surveys.js
@@ -75,6 +75,10 @@ class SurveysScreen extends Component {
           {showModal && <SurveyModal close={this.hideModal} />}
 
           <LocalSurveyList surveys={availableSurveys} />
+          <Text style={[baseStyles.wrapperContent]}>
+            Choose which surveys to edit and show on the map. One survey has to
+            be active at any time.
+          </Text>
         </ScrollView>
         <View
           style={{

--- a/app/selectors/index.js
+++ b/app/selectors/index.js
@@ -5,21 +5,28 @@ import { tilesForBounds } from "../lib";
 export const selectUser = state => state.user;
 
 export const selectAvailableSurveys = state => state.surveys.available;
+export const selectActiveSurveyIds = state => state.surveys.active;
 
-export const selectCustomSurveys = createSelector(
-  selectAvailableSurveys,
-  surveys => surveys.filter(x => !x.default)
+/**
+ * Selector that combines survey data with whether that
+ * survey is active
+ */
+export const selectSurveysWithActivity = createSelector(
+  [selectAvailableSurveys, selectActiveSurveyIds],
+  (surveys, activeIds) => {
+    return surveys.map(survey => {
+      var isActive = !!activeIds.find(id => id === survey.definition.id);
+      return Object.assign({}, { active: isActive }, survey);
+    });
+  }
 );
 
-export const selectDefaultSurveys = createSelector(
-  selectAvailableSurveys,
-  surveys => surveys.filter(x => x.default)
-);
-
+/**
+ * Selector to filter surveys by activity
+ */
 export const selectActiveSurveys = createSelector(
-  [selectCustomSurveys, selectDefaultSurveys],
-  (customSurveys, defaultSurveys) =>
-    customSurveys.length > 0 ? customSurveys : defaultSurveys
+  selectSurveysWithActivity,
+  surveys => surveys.filter(s => s.active)
 );
 
 export const selectFeatureTypes = createSelector(selectActiveSurveys, surveys =>

--- a/app/selectors/index.js
+++ b/app/selectors/index.js
@@ -15,7 +15,8 @@ export const selectSurveysWithActivity = createSelector(
   [selectAvailableSurveys, selectActiveSurveyIds],
   (surveys, activeIds) => {
     return surveys.map(survey => {
-      var isActive = !!activeIds.find(id => id === survey.definition.id);
+      let { name, id } = survey.definition;
+      var isActive = !!activeIds.find(i => i === (name || id));
       return Object.assign({}, { active: isActive }, survey);
     });
   }
@@ -238,8 +239,8 @@ export const selectVisibleFeatures = createSelector(
 );
 
 export const selectVisibleObservations = createSelector(
-  [selectVisibleBounds, selectObservationTiles],
-  (visibleBounds, observations) => {
+  [selectVisibleBounds, selectObservationTiles, selectActiveSurveyIds],
+  (visibleBounds, observations, activeIds) => {
     const tiles = tilesForBounds(visibleBounds);
 
     return tiles
@@ -250,6 +251,9 @@ export const selectVisibleObservations = createSelector(
 
         return visibleObservations;
       }, [])
+      .filter(obs => {
+        return !!activeIds.find(i => i === obs.tags.surveyId);
+      })
       .filter(
         ({ lat, lon }) =>
           // check for containment


### PR DESCRIPTION
* Change language of active / available surveys: An available survey is
any imported system, an active survey is a survey that the user has
deemed "active" in Account/Surveys. Previously active surveys meant
surveys that are not the default survey.

* Add reducer to toggle state.surveys.active which is a list of ids for
active surveys. This renders the toggles on Accounts/Surveys

* Change the backing selectors:
  - selectActiveSurveyIds: selects state.surveys.active
  - selectSurveysWithActivity: attaches state.surveys.active to the
  survey data
  - selectActiveSurveys: filters the previous selector on active=true

### TODO:
- [x] Initial survey toggles
- [x] Filter map data using active surveys
- [x] Prevent 0 surveys to be active, at least one survey has to be active
- [ ] Style cleanup and help text


![android emulator - nexus_5x_api_22 5554 2017-09-21 19-17-28](https://user-images.githubusercontent.com/719357/30722880-8b61abd8-9f01-11e7-9595-d6ddbce90feb.png)