### PR TITLE
[wip] more metadata

### DIFF
--- a/app/screens/Account/observations.js
+++ b/app/screens/Account/observations.js
@@ -179,6 +179,13 @@ class AccountObservations extends Component {
                           style={[baseStyles.wrappedItems, baseStyles.spacer]}
                         >
                           <Text>
+                            Survey: {item.tags.surveyId}
+                          </Text>
+                        </View>
+                        <View
+                          style={[baseStyles.wrappedItems, baseStyles.spacer]}
+                        >
+                          <Text>
                             Updated:{" "}
                             {format(item.timestamp, "h:mm aa ddd, MMM D, YYYY")}
                           </Text>

--- a/app/screens/Observation/choose-point.js
+++ b/app/screens/Observation/choose-point.js
@@ -3,6 +3,8 @@ import { View, TouchableOpacity, ScrollView, Dimensions } from "react-native";
 import Icon from "react-native-vector-icons/MaterialIcons";
 import { connect } from "react-redux";
 import { Link } from "react-router-native";
+import turf from "turf";
+import { max as maxDate, distanceInWordsToNow } from "date-fns";
 
 import getCenterOfPoints from "../../lib/get-center-of-points";
 import { initializeObservation } from "../../actions";
@@ -127,6 +129,8 @@ class ChoosePoint extends Component {
       </View>
     );
 
+    var origin = turf.point([center.longitude, center.latitude]);
+
     return (
       <Wrapper style={[baseStyles.wrapper]} headerView={headerView}>
         <ScrollView
@@ -195,6 +199,30 @@ class ChoosePoint extends Component {
               }}
             >
               {features.map(item => {
+                /** Calculate distance from user */
+                let distanceLabel = "km";
+                let distance = 0;
+                if (item.lon && item.lat && origin) {
+                  const location = turf.point([item.lon, item.lat]);
+                  distance = turf.distance(origin, location);
+
+                  if (distance < 1) {
+                    distance *= 1000;
+                    distanceLabel = "m";
+                  }
+                }
+
+                /** Calculate last updated */
+                let dates = [];
+                item.observations.forEach(obs => {
+                  dates.push(obs.timestamp);
+                });
+                let lastUpdated = "";
+                if (dates.length) {
+                  lastUpdated = ` | Updated: ${distanceInWordsToNow(
+                    maxDate(dates)
+                  )} ago`;
+                }
                 return (
                   <View
                     ref={this.setItemRef(item.id)}
@@ -228,8 +256,16 @@ class ChoosePoint extends Component {
                       }}
                     >
                       <Text style={[baseStyles.h3, baseStyles.headerLink]}>
-                        {item.tags.name}
+                        {" "}{item.tags.name}
                       </Text>
+                      <View style={{ flexDirection: "row", flexWrap: "wrap" }}>
+                        <Text>
+                          {`${distance.toFixed(2)} ${distanceLabel}`} away
+                        </Text>
+                        <Text>
+                          {lastUpdated}
+                        </Text>
+                      </View>
                     </TouchableOpacity>
                   </View>
                 );

--- a/app/screens/Observation/view.js
+++ b/app/screens/Observation/view.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { View, TouchableOpacity, Alert } from "react-native";
 import { connect } from "react-redux";
 import Icon from "react-native-vector-icons/MaterialIcons";
+import { format } from "date-fns";
 import { Link } from "react-router-native";
 
 import { calculateCompleteness } from "../../lib/calculate-completeness";
@@ -287,6 +288,17 @@ class ViewObservationScreen extends Component {
                 ? "Add Observation Details"
                 : "Create Observation"}
             </Text>
+            {fields != null
+              ? <Text style={[baseStyles.textWhite, { fontSize: 12 }]}>
+                  {" "}Survey: {observation.tags.surveyId}
+                </Text>
+              : <View />}
+            {observation.timestamp != null
+              ? <Text style={[baseStyles.textWhite, { fontSize: 12 }]}>
+                  {" "}Updated:{" "}
+                  {format(observation.timestamp, "h:mm aa ddd, MMM D, YYYY")}
+                </Text>
+              : <View />}
           </View>
         </View>
 


### PR DESCRIPTION
Copied from #245 
## On the cards (map view and also on the secondary point confirmation page)
- [x] Distance from user lat, lon
- [x] Last updated
- [ ] If the observation is complete or not (we have the number of observations on the cards on the map view but need them on the confirmation view)

Example:
![](https://user-images.githubusercontent.com/5421566/30749366-242301da-9f81-11e7-9887-e0d6250e9dcf.png)

## My Observation View
- [x] What survey it belongs to

## Observation view
- [x] Survey it belongs to (in the blue section)
- [x] When it was last updated (in the blue section)
- [x] Survey definition should not be in the header but above Basic Info