### PR TITLE
allow canceling the field input screen

### DIFF
--- a/app/components/field-inputs.js
+++ b/app/components/field-inputs.js
@@ -9,7 +9,6 @@ class Field extends Component {
   onValueChange = value => {
     const { field: { key }, updateObservation } = this.props;
 
-    console.log("field key", key);
     updateObservation({
       tags: {
         [key]: value
@@ -64,9 +63,6 @@ export class PickerField extends Field {
   render() {
     const { field: { key, label }, observation: { tags } } = this.props;
     const value = tags[key];
-
-    console.log("value", value);
-    console.log("tags", tags);
 
     return (
       <View ref={x => (this._root = x)} style={[baseStyles.field]}>
@@ -166,34 +162,49 @@ export class TextField extends Field {
 }
 
 export class DateField extends Field {
+  componentWillMount() {
+    this.state = { value: new Date() };
+    this.onValueChange(this.state.value);
+  }
+
   render() {
+    const {
+      field: { key, label, placeholder },
+      focusNextField,
+      observation: { tags }
+    } = this.props;
+
     return (
-      <DatePicker
-        style={{ width: 200 }}
-        date={this.props.value}
-        mode="date"
-        placeholder="select date"
-        format="YYYY-MM-DD"
-        minDate="2016-05-01"
-        maxDate="2016-06-01"
-        confirmBtnText="Confirm"
-        cancelBtnText="Cancel"
-        customStyles={{
-          dateIcon: {
-            position: "absolute",
-            left: 0,
-            top: 4,
-            marginLeft: 0
-          },
-          dateInput: {
-            marginLeft: 36
-          }
-          // ... You can check the source to find the other keys.
-        }}
-        onDateChange={date => {
-          this.setState({ date: date });
-        }}
-      />
+      <View ref={x => (this._root = x)} style={[baseStyles.field]}>
+        <View style={{ flex: 1 }}>
+          <Text style={baseStyles.fieldLabel}>
+            {label}
+          </Text>
+          <DatePicker
+            style={{ width: 200 }}
+            date={this.state.value}
+            mode="date"
+            placeholder="select date"
+            format="YYYY-MM-DD"
+            confirmBtnText="Confirm"
+            cancelBtnText="Cancel"
+            customStyles={{
+              dateIcon: {
+                position: "absolute",
+                left: 0,
+                top: 4,
+                marginLeft: 0
+              },
+              dateInput: {
+                marginLeft: 36
+              }
+            }}
+            onDateChange={date => {
+              this.onValueChange(date);
+            }}
+          />
+        </View>
+      </View>
     );
   }
 }
@@ -214,6 +225,9 @@ export const getFieldInput = type => {
 
     case "textarea":
       return TextField;
+
+    case "date":
+      return DateField;
 
     default:
       throw new Error(`Unsupported field type: ${type}`);

--- a/app/components/fields.js
+++ b/app/components/fields.js
@@ -4,6 +4,7 @@ import { View } from "react-native";
 import { Text } from ".";
 import { baseStyles } from "../styles";
 import Icon from "react-native-vector-icons/MaterialIcons";
+import { format } from "date-fns";
 
 class Field extends Component {
   setNativeProps(nativeProps) {
@@ -130,6 +131,38 @@ export class TextField extends Field {
   }
 }
 
+export class DateField extends Field {
+  render() {
+    const {
+      field: { key, label, placeholder },
+      observation: { tags }
+    } = this.props;
+    const value = tags[key]
+      ? format(tags[key] || placeholder, "h:mm aa ddd, MMM D, YYYY")
+      : null;
+
+    return (
+      <View ref={x => (this._root = x)} style={[baseStyles.field]}>
+        <View style={[baseStyles.wrappedItemsLg]}>
+          <Text style={[baseStyles.h5]}>
+            {label.toUpperCase()}
+          </Text>
+          <Text style={[baseStyles.fieldValue]}>
+            {/* TODO grey out placeholder if used */}
+            {value}
+          </Text>
+        </View>
+        <View style={[baseStyles.wrappedItemsSm]}>
+          <Icon
+            name="keyboard-arrow-right"
+            style={baseStyles.formArrowCategories}
+          />
+        </View>
+      </View>
+    );
+  }
+}
+
 export const getFieldType = type => {
   switch (type) {
     case "check":
@@ -143,6 +176,12 @@ export const getFieldType = type => {
 
     case "text":
       return TextField;
+
+    case "textarea":
+      return TextField;
+
+    case "date":
+      return DateField;
 
     default:
       throw new Error(`Unsupported field type: ${type}`);

--- a/app/screens/Observation/fieldset-form.js
+++ b/app/screens/Observation/fieldset-form.js
@@ -1,14 +1,26 @@
 import React, { Component } from "react";
-import { View, TouchableOpacity, ScrollView } from "react-native";
+import { View, TouchableOpacity, ScrollView, Dimensions } from "react-native";
 import { connect } from "react-redux";
 import Icon from "react-native-vector-icons/MaterialIcons";
 
-import { updateObservation } from "../../actions";
+import {
+  updateObservation,
+  saveObservation,
+  setActiveObservation
+} from "../../actions";
 import { Text, Wrapper, getFieldInput } from "../../components";
 import { selectActiveObservation, selectFeatureType } from "../../selectors";
 import { baseStyles } from "../../styles";
 
+const screen = Dimensions.get("window");
+
 class FieldsetFormScreen extends Component {
+  componentWillMount() {
+    this.setState({
+      observation: Object.assign({}, this.props.observation)
+    });
+  }
+
   renderField(field, index) {
     const { observation, updateObservation } = this.props;
 
@@ -30,7 +42,12 @@ class FieldsetFormScreen extends Component {
   }
 
   render() {
-    const { history, type: { fields, name } } = this.props;
+    const {
+      saveObservation,
+      setActiveObservation,
+      history,
+      type: { fields, name }
+    } = this.props;
 
     return (
       <View style={[baseStyles.modalBg]}>
@@ -42,14 +59,45 @@ class FieldsetFormScreen extends Component {
               Basic Information
             </Text>
 
-            <TouchableOpacity onPress={history.goBack}>
+            <TouchableOpacity
+              onPress={() => {
+                if (fields && fields.length > 0) {
+                  fields.forEach(({ key }) => {
+                    if (this.state.observation.tags[key]) {
+                      delete this.state.observation.tags[key];
+                    }
+                  });
+                }
+
+                setActiveObservation(this.state.observation);
+                history.goBack();
+              }}
+            >
               <Icon name="clear" style={[[baseStyles.clearIcon]]} />
             </TouchableOpacity>
           </View>
 
-          <ScrollView style={[baseStyles.fieldset]}>
+          <ScrollView style={[baseStyles.fieldset, { marginBottom: 60 }]}>
             {fields.map(this.renderField, this)}
           </ScrollView>
+
+          <View
+            style={{
+              position: "absolute",
+              bottom: 0,
+              flexDirection: "row"
+            }}
+          >
+            <TouchableOpacity
+              style={[baseStyles.buttonBottom, { width: screen.width }]}
+              onPress={() => {
+                saveObservation(this.props.observation);
+                history.goBack();
+              }}
+            >
+              <Text style={baseStyles.textWhite}>SAVE OBSERVATION</Text>
+            </TouchableOpacity>
+          </View>
         </View>
       </View>
     );
@@ -68,6 +116,8 @@ const mapStateToProps = (state, ownProps) => {
   };
 };
 
-export default connect(mapStateToProps, { updateObservation })(
-  FieldsetFormScreen
-);
+export default connect(mapStateToProps, {
+  updateObservation,
+  saveObservation,
+  setActiveObservation
+})(FieldsetFormScreen);


### PR DESCRIPTION
Closes #221 by adding a save button to the field input screen and making the cancel button restore the observation to its state before things were added.

Also fixed some small issues with viewing/editing textarea and date fields.