### PR TITLE
guard against missing timestamp, make distance and timestamp fit on one line

### DIFF
--- a/app/components/map-overlay.js
+++ b/app/components/map-overlay.js
@@ -351,7 +351,10 @@ class MapOverlay extends Component {
                   ]}
                 >
                   <Text style={[baseStyles.metadataText, { marginTop: 10 }]}>
-                    {item.observations.length} Observations
+                    {item.observations.length}{" "}
+                    {item.observations.length === 1
+                      ? "Observation"
+                      : "Observations"}
                   </Text>
                   {/*<Text style={[baseStyles.textAlert]}>(2 incomplete)</Text>*/}
                 </View>

--- a/app/components/map-overlay.js
+++ b/app/components/map-overlay.js
@@ -305,7 +305,7 @@ class MapOverlay extends Component {
             /** Calculate last updated */
             let dates = [];
             item.observations.forEach(obs => {
-              dates.push(obs.timestamp);
+              if (obs.timestamp) dates.push(obs.timestamp);
             });
             let lastUpdated = "";
             if (dates.length) {
@@ -337,10 +337,10 @@ class MapOverlay extends Component {
                   </Text>
                 </Link>
                 <View style={{ flexDirection: "row", flexWrap: "wrap" }}>
-                  <Text>
+                  <Text style={{ fontSize: 13 }}>
                     {`${distance.toFixed(2)} ${distanceLabel}`} away
                   </Text>
-                  <Text>
+                  <Text style={{ fontSize: 13 }}>
                     {lastUpdated}
                   </Text>
                 </View>

--- a/app/styles/index.js
+++ b/app/styles/index.js
@@ -308,7 +308,7 @@ const baseStyles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#ccc",
     alignContent: "center",
-    height: 130,
+    height: 140,
     padding: 20,
     paddingTop: 15,
     marginLeft: 15,


### PR DESCRIPTION
Closes #284

I'm pretty sure the error described in #284 was happening only because we had observations that were made back when we had that bug where timestamps weren't persisted.

I added this guard to make sure it doesn't cause an issue just in case.

I also made some changes to the styles to make sure distance and last updated are on the same line and give better spacing when the name of the feature is long enough to be on two lines.

Example:

<img width="332" alt="screen shot 2017-09-29 at 1 29 00 pm" src="https://user-images.githubusercontent.com/164214/31027963-3593ff8e-a51a-11e7-8f6a-987ab083ac6c.png">
