### PR TITLE
make sure osm.createObservation cb is called

### DIFF
--- a/app/lib/osm-p2p.js
+++ b/app/lib/osm-p2p.js
@@ -81,6 +81,7 @@ function osmp2p(createOsmDb) {
 
     function onObservationCreated(err, docId) {
       if (err) return cb(err);
+      var res = Object.assign(doc, { id: docId });
 
       // create a link to an osm feature only if applicable
       if (nodeId) {
@@ -90,13 +91,14 @@ function osmp2p(createOsmDb) {
           link: nodeId
         };
 
-        observationDb.create(link, function(err, linkId) {
+        return observationDb.create(link, function(err, linkId) {
           if (err) return cb(err);
-          var res = Object.assign(doc, { id: docId });
           var linkRes = Object.assign(link, { id: linkId });
           cb(null, res, linkRes);
         });
       }
+
+      cb(null, res);
     }
   }
 


### PR DESCRIPTION
closes #270 

This one turned out to be pretty straightforward. `osm.createObservation` wasn't handling the case where observations are created on a new point.