### PR TITLE
Feature/275

### DIFF
--- a/app/components/map-overlay.js
+++ b/app/components/map-overlay.js
@@ -367,9 +367,10 @@ class MapOverlay extends Component {
   };
 
   render() {
-    const { onGeolocate, observations } = this.props;
+    const { onGeolocate, observations, userLocation, history } = this.props;
     const closed = Screen.height - 45;
     const open = Screen.height - 210;
+    let features = this.state.features;
 
     return (
       <View
@@ -400,10 +401,25 @@ class MapOverlay extends Component {
         >
           <Geolocate onGeolocate={onGeolocate} />
 
-          <Link
-            to={{
-              pathname: "/observation/choose-point",
-              state: { addPoint: true, observations: observations }
+          <TouchableOpacity
+            onPress={() => {
+              if (features.length > 0) {
+                history.push("/observation/choose-point", {
+                  addPoint: true,
+                  observations: observations
+                });
+              } else {
+                if (userLocation) {
+                  const userLatitude = userLocation.latitude;
+                  const userLongitude = userLocation.longitude;
+                  this.props.initializeObservation({
+                    lat: userLatitude,
+                    lon: userLongitude,
+                    tags: { "osm-p2p-id": null }
+                  });
+                  history.push("/observation");
+                }
+              }
             }}
             style={{
               width: 60,
@@ -425,7 +441,7 @@ class MapOverlay extends Component {
                 color: "#ffffff"
               }}
             />
-          </Link>
+          </TouchableOpacity>
         </Animated.View>
 
         <Interactable.View

--- a/app/components/side-menu.js
+++ b/app/components/side-menu.js
@@ -120,12 +120,11 @@ class SideMenu extends Component {
           >
             <Link
               to={{
-                pathname: "/observation/choose-point",
-                state: { addPoint: true }
+                pathname: "/"
               }}
               style={[baseStyles.buttonBottom, { width: SideMenuWidth }]}
             >
-              <Text style={[baseStyles.textWhite]}>ADD AN OBSERVATION</Text>
+              <Text style={[baseStyles.textWhite]}>GO TO MAP</Text>
             </Link>
           </View>
         </Interactable.View>

--- a/app/screens/Observation/map.js
+++ b/app/screens/Observation/map.js
@@ -23,7 +23,8 @@ import {
   setActiveObservation,
   updateVisibleBounds,
   notifyActiveSurveys,
-  clearStatus
+  clearStatus,
+  initializeObservation
 } from "../../actions";
 import {
   AnnotationObservation,
@@ -379,6 +380,8 @@ class ObservationMapScreen extends Component {
           activeSurveys={this.props.activeSurveys}
           areaOfInterest={this.props.areaOfInterest}
           pressedFeature={this.state.pressedFeature}
+          initializeObservation={this.props.initializeObservation}
+          history={this.props.history}
           loading={loading}
           querying={querying}
           activeFeature={this.setActiveFeature}
@@ -405,5 +408,6 @@ export default connect(mapStateToProps, {
   setActiveObservation,
   updateVisibleBounds,
   notifyActiveSurveys,
-  clearStatus
+  clearStatus,
+  initializeObservation
 })(ObservationMapScreen);

--- a/app/screens/Observation/view.js
+++ b/app/screens/Observation/view.js
@@ -219,6 +219,7 @@ class ViewObservationScreen extends Component {
     const incomplete = 10 - complete;
 
     const { locationModalOpen, observationTypeModalOpen } = this.state;
+    console.log("OBSERVATION NAME", observation.tags);
 
     const headerView = (
       <View
@@ -235,7 +236,7 @@ class ViewObservationScreen extends Component {
           />
         </TouchableOpacity>
         <Text style={[baseStyles.h3, baseStyles.headerTitle]}>
-          Add Observation
+          {observation.id != null ? "Observation" : "New Observation"}
         </Text>
       </View>
     );
@@ -270,9 +271,9 @@ class ViewObservationScreen extends Component {
                 baseStyles.headerWithDescription
               ]}
             >
-              {fields != null
-                ? "Add Observation Details"
-                : "Create Observation"}
+              {observation.id != null
+                ? "Observation Details"
+                : "Add Observation Details"}
             </Text>
             {fields != null
               ? <Text style={{ color: "#E9E9E9", marginBottom: 5 }}>


### PR DESCRIPTION
#275 is a bug where there will be an empty list if there are no features around the user when clicking through to create a new observation. For me this actually crashed the app because we're calculating the center of features to display a map marker, but this breaks if there are no visibleFeatures in the state. 

This closes #275 by changing the behavior of the + button and side menu button:
- the + button will now check for visibleFeatures, if it doesn't find any it goes straight to adding a new observation initialized at the user's center location
- the side menu "I'm adding a new point" button is tricky: we don't have the user's location or the visible features around the user in the state without the map context, so we can't determine how to route the user. Without changing the way we store features in the state, I could not reroute this button. For now, I changed it such that it goes back to the map.