### PR TITLE
update react-native-mapbox-gl: fix android latlng issue

### DIFF
--- a/app/config/production.js
+++ b/app/config/production.js
@@ -1,3 +1,4 @@
 module.exports = {
-  mapboxAccessToken: process.env.MAPBOX_ACCESS_TOKEN
+  mapboxAccessToken:
+    "pk.eyJ1Ijoic2V0aHZpbmNlbnQiLCJhIjoiSXZZXzZnUSJ9.Nr_zKa-4Ztcmc1Ypl0k5nw"
 };

--- a/app/screens/Observation/map.js
+++ b/app/screens/Observation/map.js
@@ -180,6 +180,8 @@ class ObservationMapScreen extends Component {
       activeSurveys
     } = this.props;
 
+    this._mapLoaded = true;
+
     getCurrentPosition((err, data) => {
       if (data) {
         this.setState({ userLocation: data.coords });
@@ -262,7 +264,7 @@ class ObservationMapScreen extends Component {
   onUpdateBounds = () => {
     const { updateVisibleBounds } = this.props;
 
-    if (this._map) {
+    if (this._map && this._mapLoaded) {
       this._map.getBounds(bounds =>
         // NOTE getBounds returns (lat, lon, lat, lon) so we convert it here
         updateVisibleBounds([bounds[1], bounds[0], bounds[3], bounds[2]])

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,6 +832,10 @@ babel-plugin-transform-regenerator@^6.5.0:
   dependencies:
     regenerator-transform "0.9.11"
 
+babel-plugin-transform-remove-console@^6.8.5:
+  version "6.8.5"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.8.5.tgz#fde9d2d3d725530b0fadd8d31078402410386810"
+
 babel-plugin-transform-strict-mode@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
@@ -1032,21 +1036,7 @@ babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.0.20, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
-  version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.25.0"
-    babylon "^6.17.2"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.26.0:
+babel-traverse@^6.0.20, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -1060,16 +1050,21 @@ babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.0.19, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
+babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
     babel-runtime "^6.22.0"
-    esutils "^2.0.2"
+    babel-types "^6.25.0"
+    babylon "^6.17.2"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
     lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
 
-babel-types@^6.26.0:
+babel-types@^6.0.19, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -1078,13 +1073,22 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@^6.0.18, babylon@^6.17.0, babylon@^6.17.2:
-  version "6.17.4"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
+babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
+  version "6.25.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
 
-babylon@^6.18.0:
+babylon@^6.0.18, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+babylon@^6.17.0, babylon@^6.17.2:
+  version "6.17.4"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -5853,12 +5857,11 @@ react-native-localization@^0.1.30:
   resolved "https://registry.yarnpkg.com/react-native-localization/-/react-native-localization-0.1.30.tgz#7e831ec9cf6b74d658f11bd49092221bdbccd5a9"
 
 "react-native-mapbox-gl@https://github.com/sethvincent/react-native-mapbox-gl/archive/field-data.tar.gz":
-  version "5.2.0"
-  resolved "https://github.com/sethvincent/react-native-mapbox-gl/archive/field-data.tar.gz#005e665d66399a2a247eea26f8dfbfaa638e5bdb"
+  version "5.2.1"
+  resolved "https://github.com/sethvincent/react-native-mapbox-gl/archive/field-data.tar.gz#c6f45ff9bf2c62676e4f44020f7e3fc024fce90f"
   dependencies:
     babel-eslint "^6.1.2"
     lodash "^4.13.1"
-    prop-types "^15.5.10"
 
 react-native-svg@5.2.0:
   version "5.2.0"


### PR DESCRIPTION
This uses latest changes from my fork of react-native-mapbox-gl.

This closes #254 which allows us to create non-dev-mode builds. Before, creating a build in release mode would mean that when the app hit the issue described in #254, the app would crash and quit without warning as it started up.

Fixing this bug means we can create release builds, which because they are not including development-related functionality, will have better performance.

I couldn't get release builds to work without including the mapbox access token as a string instead of an environment variable. That's something we could look into later.