### PR TITLE
WIP! address indexing issues that result in empty export from desktop app

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -395,11 +395,12 @@ export const setActiveObservation = observation => dispatch =>
     observation
   });
 
-export const updateObservation = observation => dispatch =>
+export const updateObservation = observation => dispatch => {
   dispatch({
     type: types.UPDATE_OBSERVATION,
     observation
   });
+};
 
 export const saveObservation = observation => (dispatch, getState) => {
   dispatch({

--- a/app/components/map-overlay.js
+++ b/app/components/map-overlay.js
@@ -71,7 +71,7 @@ class MapOverlay extends Component {
     let { features, observations, pressedFeature } = nextProps;
     features.forEach(feature => {
       feature.observations = observations.filter(
-        obs => obs.tags["osm-p2p-id"] === feature.id
+        obs => obs.nodeId === feature.id
       );
       return feature;
     });
@@ -415,7 +415,8 @@ class MapOverlay extends Component {
                   this.props.initializeObservation({
                     lat: userLatitude,
                     lon: userLongitude,
-                    tags: { "osm-p2p-id": null }
+                    nodeId: null,
+                    tags: {}
                   });
                   history.push("/observation");
                 }

--- a/app/lib/convert-geojson-osmp2p.js
+++ b/app/lib/convert-geojson-osmp2p.js
@@ -6,7 +6,7 @@ module.exports = {
 function toOSM(feature, type) {
   var observation = {
     id: feature.id,
-    tags: feature.properties,
+    tags: feature.properties || {},
     timestamp: feature.timestamp || new Date().toISOString()
   };
 

--- a/app/screens/Observation/choose-point.js
+++ b/app/screens/Observation/choose-point.js
@@ -66,7 +66,7 @@ class ChoosePoint extends Component {
 
     features.forEach(feature => {
       feature.observations = observations.filter(
-        obs => obs.tags["osm-p2p-id"] === feature.id
+        obs => obs.nodeId === feature.id
       );
       return feature;
     });
@@ -244,7 +244,8 @@ class ChoosePoint extends Component {
                           initializeObservation({
                             lat: center.latitude,
                             lon: center.longitude,
-                            tags: { "osm-p2p-id": item.id }
+                            nodeId: item.id,
+                            tags: {}
                           });
 
                           history.push({
@@ -290,7 +291,8 @@ class ChoosePoint extends Component {
               initializeObservation({
                 lat: center.latitude,
                 lon: center.longitude,
-                tags: { "osm-p2p-id": null }
+                nodeId: null,
+                tags: {}
               });
 
               history.push("/observation");

--- a/app/screens/Observation/map.js
+++ b/app/screens/Observation/map.js
@@ -137,7 +137,7 @@ class ObservationMapScreen extends Component {
 
       if (type === "observation") {
         const observation = observations.find(o => o.id === id);
-        const featureId = observation.tags["osm-p2p-id"];
+        const featureId = observation.nodeId;
         const feature = features.find(f => f.id === featureId);
         this.setState({
           pressedFeature: feature

--- a/app/screens/OsmFeature/view.js
+++ b/app/screens/OsmFeature/view.js
@@ -111,9 +111,8 @@ class ViewOsmFeature extends Component {
     initializeObservation({
       lat: feature.lat,
       lon: feature.lon,
-      tags: {
-        "osm-p2p-id": feature.id
-      }
+      nodeId: feature.id,
+      tags: {}
     });
 
     history.push("/observation");

--- a/app/selectors/index.js
+++ b/app/selectors/index.js
@@ -266,9 +266,7 @@ export const selectVisibleObservations = createSelector(
 );
 
 export const selectVisibleObservationsByNode = nodeId => {
-  return selectVisibleObservations().filter(
-    obs => obs.tags["osm-p2p-id"] === nodeId
-  );
+  return selectVisibleObservations().filter(obs => obs.nodeId === nodeId);
 };
 
 export const selectLoadingStatus = state => state.features.loading;


### PR DESCRIPTION
This switches observations to use `doc.nodeId` for tracking the related osm node in the app.

Also this fixes the issue where `osm.createNode` was not being called when needed.

I've verified that `observation-link` documents are created with the correct values with both nodes that were imported from OSM and nodes that were created in the mobile app.

When I sync to the desktop app and export, the xml export is still empty.